### PR TITLE
Add `UseVarForPrimitive`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,3 +134,37 @@ jobs:
           antora \
           -Pantora.downloadNode=false \
           -Dscan.tag.Documentation
+
+  sanity:
+    name: Sanity Check 🕊
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository 📥
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          persist-credentials: false
+      - name: Checkstyle ☑️
+        uses: ./.github/actions/run-gradle
+        with:
+          encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          arguments: checkstyleMain
+      - name: Spotless ✨
+        uses: ./.github/actions/run-gradle
+        with:
+          encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          arguments: spotlessCheck
+      - name: ArchUnit 🏛️
+        uses: ./.github/actions/run-gradle
+        with:
+          encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          arguments: archUnit
+      - name: OSGi 🧩
+        uses: ./.github/actions/run-gradle
+        with:
+          encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          arguments: verifyOSGiTask
+      - name: Rewrite ⚙️
+        uses: ./.github/actions/run-gradle
+        with:
+          encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          arguments: rewriteDryRun -Dorg.gradle.jvmargs=-Xmx3G

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI ♻️
 
 on:
   push:
@@ -134,3 +134,37 @@ jobs:
           antora \
           -Pantora.downloadNode=false \
           -Dscan.tag.Documentation
+
+  sanity:
+    name: Sanity Check 🕊
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository 📥
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          persist-credentials: false
+      - name: Checkstyle ☑️
+        uses: ./.github/actions/run-gradle
+        with:
+          encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          arguments: checkstyleMain
+      - name: Spotless ✨
+        uses: ./.github/actions/run-gradle
+        with:
+          encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          arguments: spotlessCheck
+      - name: ArchUnit 🏛️
+        uses: ./.github/actions/run-gradle
+        with:
+          encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          arguments: archUnit
+      - name: OSGi 🧩
+        uses: ./.github/actions/run-gradle
+        with:
+          encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          arguments: verifyOSGiTask
+      - name: Rewrite ⚙️
+        uses: ./.github/actions/run-gradle
+        with:
+          encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          arguments: rewriteDryRun -Dorg.gradle.jvmargs=-Xmx3G

--- a/.github/workflows/sanity-check.yml
+++ b/.github/workflows/sanity-check.yml
@@ -1,0 +1,48 @@
+name: Sanity Check 🕊
+on:
+  push:
+    branches:
+      - main
+      - 'releases/**'
+    paths:
+      - '.github/**'
+  pull_request:
+    paths:
+      - '.github/**'
+permissions: {}
+jobs:
+  validate:
+    name: Validate 📊
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout Repository 📥
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          persist-credentials: false
+      - name: Checkstyle ☑️
+        uses: ./.github/actions/run-gradle
+        with:
+          encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          arguments: checkstyleMain
+      - name: Spotless ✨
+        uses: ./.github/actions/run-gradle
+        with:
+          encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          arguments: spotlessCheck
+      - name: ArchUnit 🏛️
+        uses: ./.github/actions/run-gradle
+        with:
+          encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          arguments: archUnit
+      - name: OSGi 🧩
+        uses: ./.github/actions/run-gradle
+        with:
+          encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          arguments: verifyOSGiTask
+      - name: Rewrite ⚙️
+        uses: ./.github/actions/run-gradle
+        with:
+          encryptionKey: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+          arguments: rewriteDryRun -Dorg.gradle.jvmargs=-Xmx3G

--- a/documentation/src/main/java/example/domain/Person.java
+++ b/documentation/src/main/java/example/domain/Person.java
@@ -52,8 +52,8 @@ public final class Person {
 
 	@Override
 	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
+		final var prime = 31;
+		var result = 1;
 		result = prime * result + ((firstName == null) ? 0 : firstName.hashCode());
 		result = prime * result + ((lastName == null) ? 0 : lastName.hashCode());
 		return result;

--- a/documentation/src/main/java/example/util/StringUtils.java
+++ b/documentation/src/main/java/example/util/StringUtils.java
@@ -17,8 +17,8 @@ import org.jspecify.annotations.Nullable;
 public class StringUtils {
 
 	public static boolean isPalindrome(@Nullable String candidate) {
-		int length = requireNonNull(candidate).length();
-		for (int i = 0; i < length / 2; i++) {
+		var length = requireNonNull(candidate).length();
+		for (var i = 0; i < length / 2; i++) {
 			if (candidate.charAt(i) != candidate.charAt(length - (i + 1))) {
 				return false;
 			}

--- a/documentation/src/tools/java/org/junit/api/tools/ApiReportGenerator.java
+++ b/documentation/src/tools/java/org/junit/api/tools/ApiReportGenerator.java
@@ -85,7 +85,7 @@ class ApiReportGenerator {
 	// -------------------------------------------------------------------------
 
 	private static Map<Status, StreamOpener> parseArgs(String[] args) {
-		Map<Status, StreamOpener> outputByStatus = new EnumMap<>(Status.class);
+		var outputByStatus = new EnumMap<Status, StreamOpener>(Status.class);
 		if (args.length == 0) {
 			outputByStatus.put(Status.EXPERIMENTAL, () -> null);
 		}
@@ -107,7 +107,7 @@ class ApiReportGenerator {
 	}
 
 	private static ApiReport generateReport(ScanResult scanResult) {
-		Map<Status, List<Declaration>> declarations = new EnumMap<>(Status.class);
+		var declarations = new EnumMap<Status, List<Declaration>>(Status.class);
 		for (var status : Status.values()) {
 			declarations.put(status, new ArrayList<>());
 		}

--- a/gradle/config/rewrite.yml
+++ b/gradle/config/rewrite.yml
@@ -1,0 +1,15 @@
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.junit.openrewrite.SanityCheck
+displayName: Apply all common best practices
+description: Comprehensive code quality recipe combining modernization, security, and best practices.
+recipeList:
+  - org.openrewrite.java.migrate.lang.var.UseVarForGenericsConstructors
+  - org.openrewrite.java.migrate.lang.var.UseVarForPrimitive
+  - org.openrewrite.staticanalysis.NoDoubleBraceInitialization
+# - org.openrewrite.gradle.UpdateGradleWrapper
+# - org.openrewrite.java.migrate.lang.var.UseVarForGenericMethodInvocations # bug
+# - org.openrewrite.java.migrate.lang.var.UseVarForObject # bug
+# - org.openrewrite.java.testing.junit.JupiterBestPractices
+# - org.openrewrite.java.testing.junit5.CleanupAssertions
+---

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -94,6 +94,7 @@ commonCustomUserData = { id = "com.gradle.common-custom-user-data-gradle-plugin"
 develocity = { id = "com.gradle.develocity", version = "4.2.2" }
 download = { id = "de.undercouch.download", version = "5.6.0" }
 errorProne = { id = "net.ltgt.errorprone", version = "4.3.0" }
+rewrite = { id = "org.openrewrite.rewrite", version = "7.22.0" }
 foojayResolver = { id = "org.gradle.toolchains.foojay-resolver", version = "1.0.0" }
 jmh = { id = "me.champeau.jmh", version = "0.7.3" }
 jreleaser = { id = "org.jreleaser", version = "1.21.0" }

--- a/gradle/plugins/common/build.gradle.kts
+++ b/gradle/plugins/common/build.gradle.kts
@@ -7,16 +7,17 @@ plugins {
 
 dependencies {
 	implementation("junitbuild.base:dsl-extensions")
-	implementation(projects.buildParameters)
 	implementation(projects.backwardCompatibility)
-	implementation(libs.plugins.kotlin.markerCoordinates)
+	implementation(projects.buildParameters)
 	implementation(libs.plugins.bnd.markerCoordinates)
 	implementation(libs.plugins.commonCustomUserData.markerCoordinates)
 	implementation(libs.plugins.develocity.markerCoordinates)
 	implementation(libs.plugins.errorProne.markerCoordinates)
 	implementation(libs.plugins.foojayResolver.markerCoordinates)
 	implementation(libs.plugins.jmh.markerCoordinates)
+	implementation(libs.plugins.kotlin.markerCoordinates)
 	implementation(libs.plugins.nullaway.markerCoordinates)
+	implementation(libs.plugins.rewrite.markerCoordinates)
 	implementation(libs.plugins.shadow.markerCoordinates)
 	implementation(libs.plugins.spotless.markerCoordinates)
 }

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.checkstyle-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.checkstyle-conventions.gradle.kts
@@ -20,7 +20,3 @@ checkstyle {
 	toolVersion = requiredVersionFromLibs("checkstyle")
 	configDirectory = rootProject.layout.projectDirectory.dir("gradle/config/checkstyle")
 }
-
-tasks.check {
-	dependsOn(tasks.withType<Checkstyle>())
-}

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.java-library-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.java-library-conventions.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 	id("junitbuild.eclipse-conventions")
 	id("junitbuild.jacoco-java-conventions")
 	id("junitbuild.java-errorprone-conventions")
+	id("junitbuild.rewrite-conventions")
 }
 
 val mavenizedProjects: List<Project> by rootProject.extra

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.osgi-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.osgi-conventions.gradle.kts
@@ -99,14 +99,21 @@ val osgiVerificationClasspath = configurations.resolvable("osgiVerificationClass
 	extendsFrom(osgiVerification.get())
 }
 
+// Make the task available for calling from outside
+tasks.register("verifyOSGiTask") {
+	description = "Verifies OSGi metadata in the built jar"
+	group = "verification"
+	dependsOn(verify)
+}
+
 // Bnd's Resolve task is what verifies that a jar can be used in OSGi and
 // that its metadata is valid. If the metadata is invalid this task will
 // fail.
-val verifyOSGi by tasks.registering(Resolve::class) {
+val verify by tasks.registering(Resolve::class) {
 	bndrun = osgiProperties.flatMap { it.destinationFile }
 	outputBndrun = layout.buildDirectory.file("resolvedOSGiProperties.bndrun")
 	isReportOptional = false
-	// By default bnd will use jars found in:
+	// By default, bnd will use jars found in:
 	// 1. project.sourceSets.main.runtimeClasspath
 	// 2. project.configurations.archives.artifacts.files
 	// to validate the metadata.
@@ -115,8 +122,4 @@ val verifyOSGi by tasks.registering(Resolve::class) {
 	// end up in the dependencies of those projects.
 	bundles(osgiVerificationClasspath)
 	properties.empty()
-}
-
-tasks.check {
-	dependsOn(verifyOSGi)
 }

--- a/gradle/plugins/common/src/main/kotlin/junitbuild.rewrite-conventions.gradle.kts
+++ b/gradle/plugins/common/src/main/kotlin/junitbuild.rewrite-conventions.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+	id("org.openrewrite.rewrite")
+}
+
+dependencies {
+	rewrite("org.openrewrite.recipe:rewrite-migrate-java:3.24.0")
+	rewrite("org.openrewrite.recipe:rewrite-static-analysis:2.23.0")
+	rewrite("org.openrewrite.recipe:rewrite-testing-frameworks:3.23.0")
+}
+
+rewrite {
+	activeRecipe("org.junit.openrewrite.SanityCheck")
+	configFile = project.getRootProject().file("gradle/config/rewrite.yml")
+	exclusion(
+		// "**AssertionsTests.java", // https://github.com/openrewrite/rewrite-static-analysis/issues/799
+		// legacy
+		"**TestCase.java",
+		"**TestCases.java",
+		"**documentation/src/test/java/example**",
+		"**testFixtures/java/org/junit/vintage/engine/samples**",
+	)
+	setExportDatatables(true)
+	setFailOnDryRunResults(true)
+}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertArrayEquals.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertArrayEquals.java
@@ -195,7 +195,7 @@ class AssertArrayEquals {
 		}
 		assertArraysHaveSameLength(expected.length, actual.length, indexes, messageOrSupplier);
 
-		for (int i = 0; i < expected.length; i++) {
+		for (var i = 0; i < expected.length; i++) {
 			if (expected[i] != actual[i]) {
 				failArraysNotEqual(expected[i], actual[i], nullSafeIndexes(indexes, i), messageOrSupplier);
 			}
@@ -217,7 +217,7 @@ class AssertArrayEquals {
 		}
 		assertArraysHaveSameLength(expected.length, actual.length, indexes, messageOrSupplier);
 
-		for (int i = 0; i < expected.length; i++) {
+		for (var i = 0; i < expected.length; i++) {
 			if (expected[i] != actual[i]) {
 				failArraysNotEqual(expected[i], actual[i], nullSafeIndexes(indexes, i), messageOrSupplier);
 			}
@@ -239,7 +239,7 @@ class AssertArrayEquals {
 		}
 		assertArraysHaveSameLength(expected.length, actual.length, indexes, messageOrSupplier);
 
-		for (int i = 0; i < expected.length; i++) {
+		for (var i = 0; i < expected.length; i++) {
 			if (expected[i] != actual[i]) {
 				failArraysNotEqual(expected[i], actual[i], nullSafeIndexes(indexes, i), messageOrSupplier);
 			}
@@ -261,7 +261,7 @@ class AssertArrayEquals {
 		}
 		assertArraysHaveSameLength(expected.length, actual.length, indexes, messageOrSupplier);
 
-		for (int i = 0; i < expected.length; i++) {
+		for (var i = 0; i < expected.length; i++) {
 			if (expected[i] != actual[i]) {
 				failArraysNotEqual(expected[i], actual[i], nullSafeIndexes(indexes, i), messageOrSupplier);
 			}
@@ -283,7 +283,7 @@ class AssertArrayEquals {
 		}
 		assertArraysHaveSameLength(expected.length, actual.length, indexes, messageOrSupplier);
 
-		for (int i = 0; i < expected.length; i++) {
+		for (var i = 0; i < expected.length; i++) {
 			if (expected[i] != actual[i]) {
 				failArraysNotEqual(expected[i], actual[i], nullSafeIndexes(indexes, i), messageOrSupplier);
 			}
@@ -305,7 +305,7 @@ class AssertArrayEquals {
 		}
 		assertArraysHaveSameLength(expected.length, actual.length, indexes, messageOrSupplier);
 
-		for (int i = 0; i < expected.length; i++) {
+		for (var i = 0; i < expected.length; i++) {
 			if (expected[i] != actual[i]) {
 				failArraysNotEqual(expected[i], actual[i], nullSafeIndexes(indexes, i), messageOrSupplier);
 			}
@@ -327,7 +327,7 @@ class AssertArrayEquals {
 		}
 		assertArraysHaveSameLength(expected.length, actual.length, indexes, messageOrSupplier);
 
-		for (int i = 0; i < expected.length; i++) {
+		for (var i = 0; i < expected.length; i++) {
 			if (!AssertionUtils.floatsAreEqual(expected[i], actual[i])) {
 				failArraysNotEqual(expected[i], actual[i], nullSafeIndexes(indexes, i), messageOrSupplier);
 			}
@@ -350,7 +350,7 @@ class AssertArrayEquals {
 		}
 		assertArraysHaveSameLength(expected.length, actual.length, indexes, messageOrSupplier);
 
-		for (int i = 0; i < expected.length; i++) {
+		for (var i = 0; i < expected.length; i++) {
 			if (!AssertionUtils.floatsAreEqual(expected[i], actual[i], delta)) {
 				failArraysNotEqual(expected[i], actual[i], nullSafeIndexes(indexes, i), messageOrSupplier);
 			}
@@ -372,7 +372,7 @@ class AssertArrayEquals {
 		}
 		assertArraysHaveSameLength(expected.length, actual.length, indexes, messageOrSupplier);
 
-		for (int i = 0; i < expected.length; i++) {
+		for (var i = 0; i < expected.length; i++) {
 			if (!AssertionUtils.doublesAreEqual(expected[i], actual[i])) {
 				failArraysNotEqual(expected[i], actual[i], nullSafeIndexes(indexes, i), messageOrSupplier);
 			}
@@ -395,7 +395,7 @@ class AssertArrayEquals {
 		}
 		assertArraysHaveSameLength(expected.length, actual.length, indexes, messageOrSupplier);
 
-		for (int i = 0; i < expected.length; i++) {
+		for (var i = 0; i < expected.length; i++) {
 			if (!AssertionUtils.doublesAreEqual(expected[i], actual[i], delta)) {
 				failArraysNotEqual(expected[i], actual[i], nullSafeIndexes(indexes, i), messageOrSupplier);
 			}
@@ -417,7 +417,7 @@ class AssertArrayEquals {
 		}
 		assertArraysHaveSameLength(expected.length, actual.length, indexes, messageOrSupplier);
 
-		for (int i = 0; i < expected.length; i++) {
+		for (var i = 0; i < expected.length; i++) {
 			Object expectedElement = expected[i];
 			Object actualElement = actual[i];
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertIterableEquals.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertIterableEquals.java
@@ -72,7 +72,7 @@ class AssertIterableEquals {
 		Iterator<?> expectedIterator = expected.iterator();
 		Iterator<?> actualIterator = actual.iterator();
 
-		int processed = 0;
+		var processed = 0;
 		while (expectedIterator.hasNext() && actualIterator.hasNext()) {
 			Object expectedElement = expectedIterator.next();
 			Object actualElement = actualIterator.next();

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertLinesMatch.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertLinesMatch.java
@@ -16,7 +16,6 @@ import static org.junit.platform.commons.util.Preconditions.condition;
 import static org.junit.platform.commons.util.Preconditions.notNull;
 
 import java.util.ArrayDeque;
-import java.util.Deque;
 import java.util.List;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.IntStream;
@@ -86,8 +85,8 @@ class AssertLinesMatch {
 			@Nullable Object messageOrSupplier) {
 
 		void assertLinesMatch() {
-			int expectedSize = expectedLines.size();
-			int actualSize = actualLines.size();
+			var expectedSize = expectedLines.size();
+			var actualSize = actualLines.size();
 
 			// trivial case: when expecting more than actual lines available, something is wrong
 			if (expectedSize > actualSize) {
@@ -106,12 +105,12 @@ class AssertLinesMatch {
 		}
 
 		void assertLinesMatchWithFastForward() {
-			Deque<String> expectedDeque = new ArrayDeque<>(expectedLines);
-			Deque<String> actualDeque = new ArrayDeque<>(actualLines);
+			var expectedDeque = new ArrayDeque<String>(expectedLines);
+			var actualDeque = new ArrayDeque<String>(actualLines);
 
 			main: while (!expectedDeque.isEmpty()) {
 				String expectedLine = expectedDeque.pop();
-				int expectedLineNumber = expectedLines.size() - expectedDeque.size(); // 1-based line number
+				var expectedLineNumber = expectedLines.size() - expectedDeque.size(); // 1-based line number
 				// trivial case: no more actual lines available
 				if (actualDeque.isEmpty()) {
 					fail("expected line #%d:`%s` not found - actual lines depleted", expectedLineNumber,
@@ -127,8 +126,8 @@ class AssertLinesMatch {
 
 				// fast-forward marker found in expected line: fast-forward actual line...
 				if (isFastForwardLine(expectedLine)) {
-					int fastForwardLimit = parseFastForwardLimit(expectedLine);
-					int actualRemaining = actualDeque.size();
+					var fastForwardLimit = parseFastForwardLimit(expectedLine);
+					var actualRemaining = actualDeque.size();
 
 					// trivial case: fast-forward marker was in last expected line
 					if (expectedDeque.isEmpty()) {
@@ -147,7 +146,7 @@ class AssertLinesMatch {
 								actualRemaining);
 						}
 						// fast-forward now: actualDeque.pop(fastForwardLimit)
-						for (int i = 0; i < fastForwardLimit; i++) {
+						for (var i = 0; i < fastForwardLimit; i++) {
 							actualDeque.pop();
 						}
 						continue; // main
@@ -167,7 +166,7 @@ class AssertLinesMatch {
 					}
 				}
 
-				int actualLineNumber = actualLines.size() - actualDeque.size() + 1; // 1-based line number
+				var actualLineNumber = actualLines.size() - actualDeque.size() + 1; // 1-based line number
 				fail("expected line #%d doesn't match actual line #%d%n" + "\texpected: `%s`%n" + "\t  actual: `%s`",
 					expectedLineNumber, actualLineNumber, expectedLine, actualLine);
 			}
@@ -207,7 +206,7 @@ class AssertLinesMatch {
 		fastForwardLine = fastForwardLine.strip();
 		String text = fastForwardLine.substring(2, fastForwardLine.length() - 2).strip();
 		try {
-			int limit = Integer.parseInt(text);
+			var limit = Integer.parseInt(text);
 			condition(limit > 0, () -> "fast-forward(%d) limit must be greater than zero".formatted(limit));
 			return limit;
 		}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTimeout.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertTimeout.java
@@ -66,8 +66,8 @@ class AssertTimeout {
 
 	private static <T extends @Nullable Object> T assertTimeout(Duration timeout, ThrowingSupplier<T> supplier,
 			@Nullable Object messageOrSupplier) {
-		long timeoutInMillis = timeout.toMillis();
-		long start = System.currentTimeMillis();
+		var timeoutInMillis = timeout.toMillis();
+		var start = System.currentTimeMillis();
 		T result;
 		try {
 			result = supplier.get();
@@ -76,7 +76,7 @@ class AssertTimeout {
 			throw throwAsUncheckedException(ex);
 		}
 
-		long timeElapsed = System.currentTimeMillis() - start;
+		var timeElapsed = System.currentTimeMillis() - start;
 		if (timeElapsed > timeoutInMillis) {
 			assertionFailure() //
 					.message(messageOrSupplier) //

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionFailureBuilder.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/AssertionFailureBuilder.java
@@ -216,8 +216,8 @@ public class AssertionFailureBuilder {
 		var pruneTargetClassName = trimStackTraceTarget.getName();
 		var stackTrace = throwable.getStackTrace();
 
-		int lastIndexOf = -1;
-		for (int i = 0; i < stackTrace.length; i++) {
+		var lastIndexOf = -1;
+		for (var i = 0; i < stackTrace.length; i++) {
 			var element = stackTrace[i];
 			var className = element.getClassName();
 			if (className.equals(pruneTargetClassName)) {
@@ -226,7 +226,7 @@ public class AssertionFailureBuilder {
 		}
 
 		if (lastIndexOf != -1) {
-			int from = clamp0(lastIndexOf + 1 - retainStackTraceElements, stackTrace.length);
+			var from = clamp0(lastIndexOf + 1 - retainStackTraceElements, stackTrace.length);
 			var trimmed = Arrays.copyOfRange(stackTrace, from, stackTrace.length);
 			throwable.setStackTrace(trimmed);
 		}

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/DisplayNameGenerator.java
@@ -221,7 +221,7 @@ public interface DisplayNameGenerator {
 		@Override
 		public String generateDisplayNameForClass(Class<?> testClass) {
 			String name = testClass.getName();
-			int lastDot = name.lastIndexOf('.');
+			var lastDot = name.lastIndexOf('.');
 			return name.substring(lastDot + 1);
 		}
 
@@ -414,7 +414,7 @@ public interface DisplayNameGenerator {
 
 			// Only build prefix based on the enclosing class if the enclosing
 			// class is also configured to use the IndicativeSentences generator.
-			boolean buildPrefix = findDisplayNameGeneration(enclosingClass, remainingEnclosingInstanceTypes)//
+			var buildPrefix = findDisplayNameGeneration(enclosingClass, remainingEnclosingInstanceTypes)//
 					.map(DisplayNameGeneration::value)//
 					.filter(IndicativeSentences.class::equals)//
 					.isPresent();

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/AbstractJreRangeCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/AbstractJreRangeCondition.java
@@ -36,10 +36,10 @@ abstract class AbstractJreRangeCondition<A extends Annotation> extends BooleanEx
 	protected final boolean isCurrentVersionWithinRange(JRE minJre, JRE maxJre, int minVersion, int maxVersion) {
 		String annotationName = super.annotationType.getSimpleName();
 
-		boolean minJreSet = minJre != JRE.UNDEFINED;
-		boolean maxJreSet = maxJre != JRE.UNDEFINED;
-		boolean minVersionSet = minVersion != JRE.UNDEFINED_VERSION;
-		boolean maxVersionSet = maxVersion != JRE.UNDEFINED_VERSION;
+		var minJreSet = minJre != JRE.UNDEFINED;
+		var maxJreSet = maxJre != JRE.UNDEFINED;
+		var minVersionSet = minVersion != JRE.UNDEFINED_VERSION;
+		var maxVersionSet = maxVersion != JRE.UNDEFINED_VERSION;
 
 		// Users must choose between JRE enum constants and version numbers.
 		Preconditions.condition(!minJreSet || !minVersionSet,

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOsCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/DisabledOnOsCondition.java
@@ -30,12 +30,12 @@ class DisabledOnOsCondition extends AbstractOsBasedExecutionCondition<DisabledOn
 
 	@Override
 	ConditionEvaluationResult evaluateExecutionCondition(DisabledOnOs annotation) {
-		boolean osSpecified = annotation.value().length > 0;
-		boolean archSpecified = annotation.architectures().length > 0;
+		var osSpecified = annotation.value().length > 0;
+		var archSpecified = annotation.architectures().length > 0;
 		Preconditions.condition(osSpecified || archSpecified,
 			"You must declare at least one OS or architecture in @DisabledOnOs");
 
-		boolean enabled = isEnabledBasedOnOs(annotation) || isEnabledBasedOnArchitecture(annotation);
+		var enabled = isEnabledBasedOnOs(annotation) || isEnabledBasedOnArchitecture(annotation);
 		String reason = createReason(enabled, osSpecified, archSpecified);
 
 		return enabled ? ConditionEvaluationResult.enabled(reason)

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnOsCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/EnabledOnOsCondition.java
@@ -30,12 +30,12 @@ class EnabledOnOsCondition extends AbstractOsBasedExecutionCondition<EnabledOnOs
 
 	@Override
 	ConditionEvaluationResult evaluateExecutionCondition(EnabledOnOs annotation) {
-		boolean osSpecified = annotation.value().length > 0;
-		boolean archSpecified = annotation.architectures().length > 0;
+		var osSpecified = annotation.value().length > 0;
+		var archSpecified = annotation.architectures().length > 0;
 		Preconditions.condition(osSpecified || archSpecified,
 			"You must declare at least one OS or architecture in @EnabledOnOs");
 
-		boolean enabled = isEnabledBasedOnOs(annotation) && isEnabledBasedOnArchitecture(annotation);
+		var enabled = isEnabledBasedOnOs(annotation) && isEnabledBasedOnArchitecture(annotation);
 		String reason = createReason(enabled, osSpecified, archSpecified);
 
 		return enabled ? ConditionEvaluationResult.enabled(reason)

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/MethodBasedCondition.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/condition/MethodBasedCondition.java
@@ -97,7 +97,7 @@ abstract class MethodBasedCondition<A extends Annotation> implements ExecutionCo
 	}
 
 	private boolean acceptsExtensionContextOrNoArguments(Method method) {
-		int parameterCount = method.getParameterCount();
+		var parameterCount = method.getParameterCount();
 		return parameterCount == 0 || (parameterCount == 1 && method.getParameterTypes()[0] == ExtensionContext.class);
 	}
 

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/ExtensionContext.java
@@ -960,7 +960,7 @@ public interface ExtensionContext {
 		public Namespace append(Object... parts) {
 			Preconditions.notEmpty(parts, "parts array must not be null or empty");
 			Preconditions.containsNoNullElements(parts, "individual parts must not be null");
-			ArrayList<Object> newParts = new ArrayList<>(this.parts.size() + parts.length);
+			var newParts = new ArrayList<Object>(this.parts.size() + parts.length);
 			newParts.addAll(this.parts);
 			Collections.addAll(newParts, parts);
 			return new Namespace(newParts);

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestInstancePreDestroyCallback.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/extension/TestInstancePreDestroyCallback.java
@@ -14,7 +14,6 @@ import static org.apiguardian.api.API.Status.STABLE;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -109,7 +108,7 @@ public interface TestInstancePreDestroyCallback extends Extension {
 	 */
 	@API(status = STABLE, since = "5.10")
 	static void preDestroyTestInstances(ExtensionContext context, Consumer<Object> callback) {
-		List<Object> destroyedInstances = new ArrayList<>(context.getRequiredTestInstances().getAllInstances());
+		var destroyedInstances = new ArrayList<Object>(context.getRequiredTestInstances().getAllInstances());
 		for (Optional<ExtensionContext> current = context.getParent(); current.isPresent(); current = current.get().getParent()) {
 			current.get().getTestInstances().map(TestInstances::getAllInstances).ifPresent(
 				destroyedInstances::removeAll);

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/timeout/PreemptiveTimeoutUtils.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/timeout/PreemptiveTimeoutUtils.java
@@ -61,7 +61,7 @@ public class PreemptiveTimeoutUtils {
 			ThrowingSupplier<T> supplier, @Nullable Supplier<@Nullable String> messageSupplier,
 			TimeoutFailureFactory<E> failureFactory) throws E {
 
-		AtomicReference<Thread> threadReference = new AtomicReference<>();
+		var threadReference = new AtomicReference<Thread>();
 		ExecutorService executorService = Executors.newSingleThreadExecutor(new TimeoutThreadFactory());
 
 		try {

--- a/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/DefaultTimeZoneExtension.java
+++ b/junit-jupiter-api/src/main/java/org/junit/jupiter/api/util/DefaultTimeZoneExtension.java
@@ -67,8 +67,8 @@ final class DefaultTimeZoneExtension implements BeforeAllCallback, BeforeEachCal
 	}
 
 	private static void validateCorrectConfiguration(DefaultTimeZone annotation) {
-		boolean noValue = annotation.value().isEmpty();
-		boolean noProvider = annotation.timeZoneProvider() == NullTimeZoneProvider.class;
+		var noValue = annotation.value().isEmpty();
+		var noProvider = annotation.timeZoneProvider() == NullTimeZoneProvider.class;
 		if (noValue == noProvider) {
 			throw new ExtensionConfigurationException(
 				"Either a valid time zone id or a TimeZoneProvider must be provided to "

--- a/junit-jupiter-api/src/testFixtures/java/org/junit/jupiter/api/AssertionTestUtils.java
+++ b/junit-jupiter-api/src/testFixtures/java/org/junit/jupiter/api/AssertionTestUtils.java
@@ -122,7 +122,7 @@ public class AssertionTestUtils {
 		Throwable[] suppressed = multipleFailuresError.getSuppressed();
 		assertEquals(exceptionTypes.length, suppressed.length, "number of suppressed exceptions");
 
-		for (int i = 0; i < exceptionTypes.length; i++) {
+		for (var i = 0; i < exceptionTypes.length; i++) {
 			assertEquals(exceptionTypes[i], failures.get(i).getClass(), "exception type [" + i + "]");
 			assertEquals(exceptionTypes[i], suppressed[i].getClass(), "suppressed exception type [" + i + "]");
 		}

--- a/junit-jupiter-api/src/testFixtures/java/org/junit/jupiter/api/fixtures/TrackLogRecords.java
+++ b/junit-jupiter-api/src/testFixtures/java/org/junit/jupiter/api/fixtures/TrackLogRecords.java
@@ -60,8 +60,8 @@ public @interface TrackLogRecords {
 
 		@Override
 		public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
-			boolean isTestMethodLevel = extensionContext.getTestMethod().isPresent();
-			boolean isListener = parameterContext.getParameter().getType() == LogRecordListener.class;
+			var isTestMethodLevel = extensionContext.getTestMethod().isPresent();
+			var isListener = parameterContext.getParameter().getType() == LogRecordListener.class;
 			return isTestMethodLevel && isListener;
 		}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassBasedTestDescriptor.java
@@ -510,7 +510,7 @@ public abstract class ClassBasedTestDescriptor extends JupiterTestDescriptor
 
 	private void registerAfterEachMethodAdapters(ExtensionRegistrar registrar) {
 		// Make a local copy since findAfterEachMethods() returns an immutable list.
-		List<Method> afterEachMethods = new ArrayList<>(requireLifecycleMethods().afterEach);
+		var afterEachMethods = new ArrayList<Method>(requireLifecycleMethods().afterEach);
 
 		// Since the bottom-up ordering of afterEachMethods will later be reversed when the
 		// synthesized AfterEachMethodAdapters are executed within TestMethodTestDescriptor,
@@ -589,7 +589,7 @@ public abstract class ClassBasedTestDescriptor extends JupiterTestDescriptor
 
 		LifecycleMethods(ClassInfo classInfo) {
 			Class<?> testClass = classInfo.testClass;
-			boolean requireStatic = classInfo.lifecycle == Lifecycle.PER_METHOD;
+			var requireStatic = classInfo.lifecycle == Lifecycle.PER_METHOD;
 			DiscoveryIssueReporter issueReporter = DiscoveryIssueReporter.collecting(discoveryIssues);
 			this.beforeAll = findBeforeAllMethods(testClass, requireStatic, issueReporter);
 			this.afterAll = findAfterAllMethods(testClass, requireStatic, issueReporter);

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTemplateTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ClassTemplateTestDescriptor.java
@@ -85,7 +85,7 @@ public class ClassTemplateTestDescriptor extends ClassBasedTestDescriptor implem
 
 	@Override
 	protected void validateClassTemplateInvocationLifecycleMethods(DiscoveryIssueReporter reporter) {
-		boolean requireStatic = this.classInfo.lifecycle == PER_METHOD;
+		var requireStatic = this.classInfo.lifecycle == PER_METHOD;
 		validateClassTemplateInvocationLifecycleMethodsAreDeclaredCorrectly(getTestClass(), requireStatic, reporter);
 	}
 
@@ -134,7 +134,7 @@ public class ClassTemplateTestDescriptor extends ClassBasedTestDescriptor implem
 		// Second iteration to avoid processing children that were pruned in the first iteration
 		this.children.forEach(child -> {
 			if (child instanceof ClassTemplateInvocationTestDescriptor descriptor) {
-				int index = descriptor.getIndex();
+				var index = descriptor.getIndex();
 				this.dynamicDescendantFilter.allowIndex(index - 1);
 				this.childrenPrototypesByIndex.put(index, child.getChildren());
 			}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ExtensionUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ExtensionUtils.java
@@ -95,7 +95,7 @@ final class ExtensionUtils {
 				.forEach(field -> {
 					List<Class<? extends Extension>> extensionTypes = streamDeclarativeExtensionTypes(field).collect(
 						toList());
-					boolean isExtendWithPresent = !extensionTypes.isEmpty();
+					var isExtendWithPresent = !extensionTypes.isEmpty();
 
 					if (isExtendWithPresent) {
 						extensionTypes.forEach(registrar::registerExtension);
@@ -124,7 +124,7 @@ final class ExtensionUtils {
 				.forEach(field -> {
 					List<Class<? extends Extension>> extensionTypes = streamDeclarativeExtensionTypes(field).collect(
 						toList());
-					boolean isExtendWithPresent = !extensionTypes.isEmpty();
+					var isExtendWithPresent = !extensionTypes.isEmpty();
 
 					if (isExtendWithPresent) {
 						extensionTypes.forEach(registrar::registerExtension);

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/JupiterTestDescriptor.java
@@ -80,11 +80,11 @@ public abstract class JupiterTestDescriptor extends AbstractTestDescriptor
 
 	static Set<TestTag> getTags(AnnotatedElement element, Supplier<String> elementDescription,
 			Supplier<TestSource> sourceProvider, Consumer<DiscoveryIssue> issueCollector) {
-		AtomicReference<@Nullable TestSource> source = new AtomicReference<>();
+		var source = new AtomicReference<@Nullable TestSource>();
 		return findRepeatableAnnotations(element, Tag.class).stream() //
 				.map(Tag::value) //
 				.filter(tag -> {
-					boolean isValid = TestTag.isValid(tag);
+					var isValid = TestTag.isValid(tag);
 					if (!isValid) {
 						String message = "Invalid tag syntax in @Tag(\"%s\") declaration on %s. Tag will be ignored.".formatted(
 							tag, elementDescription.get());

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/MethodBasedTestDescriptor.java
@@ -81,7 +81,7 @@ public abstract class MethodBasedTestDescriptor extends JupiterTestDescriptor
 	@Override
 	public final Set<TestTag> getTags() {
 		// return modifiable copy
-		Set<TestTag> allTags = new LinkedHashSet<>(this.methodInfo.tags);
+		var allTags = new LinkedHashSet<TestTag>(this.methodInfo.tags);
 		getParent().ifPresent(parentDescriptor -> allTags.addAll(parentDescriptor.getTags()));
 		return allTags;
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/NestedClassTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/NestedClassTestDescriptor.java
@@ -74,7 +74,7 @@ public class NestedClassTestDescriptor extends ClassBasedTestDescriptor {
 	@Override
 	public final Set<TestTag> getTags() {
 		// return modifiable copy
-		Set<TestTag> allTags = new LinkedHashSet<>(this.classInfo.tags);
+		var allTags = new LinkedHashSet<TestTag>(this.classInfo.tags);
 		getParent().ifPresent(parentDescriptor -> allTags.addAll(parentDescriptor.getTags()));
 		return allTags;
 	}
@@ -89,7 +89,7 @@ public class NestedClassTestDescriptor extends ClassBasedTestDescriptor {
 	@API(status = INTERNAL, since = "5.12")
 	public static List<Class<?>> getEnclosingTestClasses(@Nullable TestDescriptor parent) {
 		if (parent instanceof TestClassAware testClassAwareParent) {
-			List<Class<?>> result = new ArrayList<>(testClassAwareParent.getEnclosingTestClasses());
+			var result = new ArrayList<Class<?>>(testClassAwareParent.getEnclosingTestClasses());
 			result.add(testClassAwareParent.getTestClass());
 			return List.copyOf(result);
 		}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ResourceLockAware.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/ResourceLockAware.java
@@ -13,7 +13,6 @@ package org.junit.jupiter.engine.descriptor;
 import static org.junit.jupiter.api.parallel.ResourceLockTarget.CHILDREN;
 
 import java.util.ArrayDeque;
-import java.util.Deque;
 import java.util.List;
 import java.util.Set;
 import java.util.function.BiFunction;
@@ -33,7 +32,7 @@ interface ResourceLockAware extends TestDescriptor {
 
 	default Stream<ExclusiveResource> determineExclusiveResources() {
 
-		Deque<ResourceLockAware> ancestors = new ArrayDeque<>();
+		var ancestors = new ArrayDeque<ResourceLockAware>();
 		TestDescriptor parent = this.getParent().orElse(null);
 		while (parent instanceof ResourceLockAware resourceLockAwareParent) {
 			ancestors.addFirst(resourceLockAwareParent);

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TemplateExecutor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TemplateExecutor.java
@@ -50,7 +50,7 @@ abstract class TemplateExecutor<P extends Extension, C> {
 	private void executeForProvider(P provider, AtomicInteger invocationIndex,
 			Node.DynamicTestExecutor dynamicTestExecutor, ExtensionContext extensionContext) {
 
-		int initialValue = invocationIndex.get();
+		var initialValue = invocationIndex.get();
 
 		Stream<? extends C> stream = provideContexts(provider, extensionContext);
 		try {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.java
@@ -116,7 +116,7 @@ public class TestFactoryTestDescriptor extends TestMethodTestDescriptor implemen
 			TestSource defaultTestSource = getSource().orElseThrow(
 				() -> new JUnitException("Illegal state: TestSource must be present"));
 			try (Stream<DynamicNode> dynamicNodeStream = toDynamicNodeStream(testFactoryMethodResult)) {
-				int index = 1;
+				var index = 1;
 				Iterator<DynamicNode> iterator = dynamicNodeStream.iterator();
 				while (iterator.hasNext()) {
 					DynamicNode dynamicNode = iterator.next();

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/AbstractOrderingVisitor.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/AbstractOrderingVisitor.java
@@ -166,12 +166,12 @@ abstract class AbstractOrderingVisitor implements TestDescriptor.Visitor {
 		}
 
 		private void orderWrappers(PARENT parentTestDescriptor, List<WRAPPER> wrappers, Consumer<String> errorHandler) {
-			List<WRAPPER> orderedWrappers = new ArrayList<>(wrappers);
+			var orderedWrappers = new ArrayList<WRAPPER>(wrappers);
 			requireNonNull(this.orderingAction).order(parentTestDescriptor, orderedWrappers);
 			Map<Object, Integer> distinctWrappersToIndex = distinctWrappersToIndex(orderedWrappers);
 
-			int difference = orderedWrappers.size() - wrappers.size();
-			int distinctDifference = distinctWrappersToIndex.size() - wrappers.size();
+			var difference = orderedWrappers.size() - wrappers.size();
+			var distinctDifference = distinctWrappersToIndex.size() - wrappers.size();
 			if (difference > 0) { // difference >= distinctDifference
 				reportDescriptorsAddedWarning(difference, errorHandler, parentTestDescriptor);
 			}
@@ -183,8 +183,8 @@ abstract class AbstractOrderingVisitor implements TestDescriptor.Visitor {
 		}
 
 		private Map<Object, Integer> distinctWrappersToIndex(List<?> wrappers) {
-			Map<Object, Integer> toIndex = new HashMap<>();
-			for (int i = 0; i < wrappers.size(); i++) {
+			var toIndex = new HashMap<Object, Integer>();
+			for (var i = 0; i < wrappers.size(); i++) {
 				// Avoid ClassCastException if a misbehaving ordering action added a non-WRAPPER
 				Object wrapper = wrappers.get(i);
 				if (!toIndex.containsKey(wrapper)) {

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassSelectorResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/ClassSelectorResolver.java
@@ -152,7 +152,7 @@ class ClassSelectorResolver implements SelectorResolver {
 			case ClassTemplateInvocationTestDescriptor.SEGMENT_TYPE -> {
 				Optional<ClassTemplateInvocationTestDescriptor> testDescriptor = context.addToParent(
 					() -> selectUniqueId(uniqueId.removeLastSegment()), parent -> {
-						int index = Integer.parseInt(lastSegment.getValue().substring(1));
+						var index = Integer.parseInt(lastSegment.getValue().substring(1));
 						return Optional.of(newDummyClassTemplateInvocationTestDescriptor(parent, index));
 					});
 				yield toInvocationMatch(testDescriptor) //
@@ -286,7 +286,7 @@ class ClassSelectorResolver implements SelectorResolver {
 	}
 
 	private static List<Class<?>> getTestClasses(TestClassAware testDescriptor) {
-		List<Class<?>> testClasses = new ArrayList<>(testDescriptor.getEnclosingTestClasses());
+		var testClasses = new ArrayList<Class<?>>(testDescriptor.getEnclosingTestClasses());
 		testClasses.add(testDescriptor.getTestClass());
 		return testClasses;
 	}
@@ -318,7 +318,7 @@ class ClassSelectorResolver implements SelectorResolver {
 		if (classes.size() == 1) {
 			return DiscoverySelectors.selectClass(classes.get(0));
 		}
-		int lastIndex = classes.size() - 1;
+		var lastIndex = classes.size() - 1;
 		return DiscoverySelectors.selectNestedClass(classes.subList(0, lastIndex), classes.get(lastIndex));
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodSelectorResolver.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/MethodSelectorResolver.java
@@ -90,7 +90,7 @@ class MethodSelectorResolver implements SelectorResolver {
 			if (testClasses.size() == 1) {
 				return resolve(context, emptyList(), testClasses.get(0), methodSelector::method, Match::exact);
 			}
-			int lastIndex = testClasses.size() - 1;
+			var lastIndex = testClasses.size() - 1;
 			return resolve(context, testClasses.subList(0, lastIndex), testClasses.get(lastIndex),
 				methodSelector::method, Match::exact);
 		}
@@ -132,7 +132,7 @@ class MethodSelectorResolver implements SelectorResolver {
 				.map(methodType -> methodType.resolveUniqueIdIntoTestDescriptor(uniqueId, context, configuration))
 				.flatMap(Optional::stream)
 				.map(testDescriptor -> {
-					boolean exactMatch = uniqueId.equals(testDescriptor.getUniqueId());
+					var exactMatch = uniqueId.equals(testDescriptor.getUniqueId());
 					if (testDescriptor instanceof Filterable filterable) {
 						if (exactMatch) {
 							filterable.getDynamicDescendantFilter().allowAll();

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestFactoryMethod.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/IsTestFactoryMethod.java
@@ -62,7 +62,7 @@ public class IsTestFactoryMethod extends IsTestableMethod {
 			issueReporter.reportIssue(createTooGenericReturnTypeIssue(method));
 			return true;
 		}
-		boolean validContainerType = !returnType.isArray() && isConvertibleToStream(returnType);
+		var validContainerType = !returnType.isArray() && isConvertibleToStream(returnType);
 		return validContainerType && isCompatibleContainerType(method, issueReporter);
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/TestClassPredicates.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/discovery/predicates/TestClassPredicates.java
@@ -90,8 +90,8 @@ public class TestClassPredicates {
 	}
 
 	public @Nullable NestedClassInvalidityReason validateNestedTestClass(Class<?> candidate) {
-		boolean isInner = this.isInnerNestedClass.check(candidate);
-		boolean isNotPrivateUnlessAbstract = this.isNotPrivateUnlessAbstractNestedClass.check(candidate);
+		var isInner = this.isInnerNestedClass.check(candidate);
+		var isNotPrivateUnlessAbstract = this.isNotPrivateUnlessAbstractNestedClass.check(candidate);
 		if (isNotPrivateUnlessAbstract && isNotAbstract(candidate)) {
 			return isInner ? null : NestedClassInvalidityReason.NOT_INNER;
 		}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/DefaultTestInstances.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/DefaultTestInstances.java
@@ -30,7 +30,7 @@ public class DefaultTestInstances implements TestInstances {
 	}
 
 	public static DefaultTestInstances of(TestInstances testInstances, Object instance) {
-		List<Object> allInstances = new ArrayList<>(testInstances.getAllInstances());
+		var allInstances = new ArrayList<Object>(testInstances.getAllInstances());
 		allInstances.add(instance);
 		return new DefaultTestInstances(Collections.unmodifiableList(allInstances));
 	}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/InterceptingExecutableInvoker.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/InterceptingExecutableInvoker.java
@@ -62,7 +62,7 @@ public class InterceptingExecutableInvoker {
 		@Nullable
 		Object[] arguments = resolveParameters(constructor, Optional.empty(), outerInstance, extensionContext,
 			extensionRegistry);
-		ConstructorInvocation<T> invocation = new ConstructorInvocation<>(constructor, arguments);
+		var invocation = new ConstructorInvocation<T>(constructor, arguments);
 		return invoke(invocation, invocation, extensionContext, extensionRegistry, interceptorCall);
 	}
 
@@ -94,7 +94,7 @@ public class InterceptingExecutableInvoker {
 				: Optional.ofNullable(target));
 		@Nullable
 		Object[] arguments = resolveParameters(method, optionalTarget, extensionContext, extensionRegistry);
-		MethodInvocation<T> invocation = new MethodInvocation<>(method, optionalTarget, arguments);
+		var invocation = new MethodInvocation<T>(method, optionalTarget, arguments);
 		return invoke(invocation, invocation, extensionContext, extensionRegistry, interceptorCall);
 	}
 

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/InvocationInterceptorChain.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/InvocationInterceptorChain.java
@@ -42,7 +42,7 @@ public class InvocationInterceptorChain {
 	private <T> T chainAndInvoke(Invocation<T> invocation, InterceptorCall<T> call,
 			List<InvocationInterceptor> interceptors) {
 
-		ValidatingInvocation<T> validatingInvocation = new ValidatingInvocation<>(invocation, interceptors);
+		var validatingInvocation = new ValidatingInvocation<T>(invocation, interceptors);
 		Invocation<T> chainedInvocation = chainInterceptors(validatingInvocation, call, interceptors);
 		T result = proceed(chainedInvocation);
 		validatingInvocation.verifyInvokedAtLeastOnce();

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ParameterResolutionUtils.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/execution/ParameterResolutionUtils.java
@@ -107,7 +107,7 @@ public class ParameterResolutionUtils {
 
 		@Nullable
 		Object[] values = new Object[parameters.length];
-		int start = 0;
+		var start = 0;
 
 		// Ensure that the outer instance is resolved as the first parameter if
 		// the executable is a constructor for an inner class.
@@ -117,7 +117,7 @@ public class ParameterResolutionUtils {
 		}
 
 		// Resolve remaining parameters dynamically
-		for (int i = start; i < parameters.length; i++) {
+		for (var i = start; i < parameters.length; i++) {
 			ParameterContext parameterContext = new DefaultParameterContext(parameters[i], i, target);
 			values[i] = resolveParameter(parameterContext, executable, extensionContext, extensionRegistry);
 		}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/MutableExtensionRegistry.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/MutableExtensionRegistry.java
@@ -104,7 +104,7 @@ public class MutableExtensionRegistry implements ExtensionRegistry, ExtensionReg
 		ServiceLoader<Extension> serviceLoader = ServiceLoader.load(Extension.class,
 			ClassLoaderUtils.getDefaultClassLoader());
 		ServiceLoaderUtils.filter(serviceLoader, clazz -> {
-			boolean included = filter.test(clazz);
+			var included = filter.test(clazz);
 			if (!included) {
 				excludedExtensions.add(clazz);
 			}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepeatedTestExtension.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepeatedTestExtension.java
@@ -41,9 +41,9 @@ class RepeatedTestExtension implements TestTemplateInvocationContextProvider {
 		Method testMethod = context.getRequiredTestMethod();
 		String displayName = context.getDisplayName();
 		RepeatedTest repeatedTest = findAnnotation(testMethod, RepeatedTest.class).get();
-		int totalRepetitions = totalRepetitions(repeatedTest, testMethod);
+		var totalRepetitions = totalRepetitions(repeatedTest, testMethod);
 		AtomicInteger failureCount = new AtomicInteger();
-		int failureThreshold = failureThreshold(repeatedTest, testMethod);
+		var failureThreshold = failureThreshold(repeatedTest, testMethod);
 		RepeatedTestDisplayNameFormatter formatter = displayNameFormatter(repeatedTest, testMethod, displayName);
 
 		// @formatter:off
@@ -55,7 +55,7 @@ class RepeatedTestExtension implements TestTemplateInvocationContextProvider {
 	}
 
 	private int totalRepetitions(RepeatedTest repeatedTest, Method method) {
-		int repetitions = repeatedTest.value();
+		var repetitions = repeatedTest.value();
 		Preconditions.condition(repetitions > 0,
 			() -> "Configuration error: @RepeatedTest on method [%s] must be declared with a positive 'value'.".formatted(
 				method));
@@ -63,9 +63,9 @@ class RepeatedTestExtension implements TestTemplateInvocationContextProvider {
 	}
 
 	private int failureThreshold(RepeatedTest repeatedTest, Method method) {
-		int failureThreshold = repeatedTest.failureThreshold();
+		var failureThreshold = repeatedTest.failureThreshold();
 		if (failureThreshold != Integer.MAX_VALUE) {
-			int repetitions = repeatedTest.value();
+			var repetitions = repeatedTest.value();
 			Preconditions.condition((failureThreshold > 0) && (failureThreshold < repetitions),
 				() -> """
 						Configuration error: @RepeatedTest on method [%s] must declare a \

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepetitionExtension.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/RepetitionExtension.java
@@ -68,7 +68,7 @@ class RepetitionExtension implements ParameterResolver, TestWatcher, ExecutionCo
 
 	@Override
 	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
-		int failureThreshold = this.repetitionInfo.getFailureThreshold();
+		var failureThreshold = this.repetitionInfo.getFailureThreshold();
 		if (this.repetitionInfo.getFailureCount() >= failureThreshold) {
 			return disabled("Failure threshold [" + failureThreshold + "] exceeded");
 		}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/SameThreadTimeoutInvocation.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/SameThreadTimeoutInvocation.java
@@ -55,7 +55,7 @@ class SameThreadTimeoutInvocation<T extends @Nullable Object> implements Invocat
 			failure = t;
 		}
 		finally {
-			boolean cancelled = future.cancel(false);
+			var cancelled = future.cancel(false);
 			if (!cancelled) {
 				future.get();
 			}

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TempDirectory.java
@@ -41,7 +41,6 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.DosFileAttributeView;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.function.Predicate;
@@ -359,7 +358,7 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 		 * @since 5.12
 		 */
 		private static String descriptionFor(Executable executable) {
-			boolean isConstructor = executable instanceof Constructor<?>;
+			var isConstructor = executable instanceof Constructor<?>;
 			String type = isConstructor ? "constructor" : "method";
 			String name = isConstructor ? executable.getDeclaringClass().getSimpleName() : executable.getName();
 			return "%s %s(%s)".formatted(type, name,
@@ -374,8 +373,8 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 				return Collections.emptySortedMap();
 			}
 
-			SortedMap<Path, IOException> failures = new TreeMap<>();
-			Set<Path> retriedPaths = new HashSet<>();
+			var failures = new TreeMap<Path, IOException>();
+			var retriedPaths = new HashSet<Path>();
 			Path rootRealPath = rootDir.toRealPath();
 
 			tryToResetPermissions(rootDir);
@@ -461,7 +460,7 @@ class TempDirectory implements BeforeAllCallback, BeforeEachCallback, ParameterR
 				}
 
 				private void resetPermissionsAndTryToDeleteAgain(Path path, IOException exception) {
-					boolean notYetRetried = retriedPaths.add(path);
+					var notYetRetried = retriedPaths.add(path);
 					if (notYetRetried) {
 						try {
 							tryToResetPermissions(path);

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutDurationParser.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutDurationParser.java
@@ -49,7 +49,7 @@ class TimeoutDurationParser {
 	TimeoutDuration parse(CharSequence text) throws DateTimeParseException {
 		Matcher matcher = PATTERN.matcher(text);
 		if (matcher.matches()) {
-			long value = Long.parseLong(matcher.group(1));
+			var value = Long.parseLong(matcher.group(1));
 			String unitAbbreviation = matcher.group(2);
 			TimeUnit unit = unitAbbreviation == null ? SECONDS
 					: requireNonNull(UNITS_BY_ABBREVIATION.get(unitAbbreviation.toLowerCase(Locale.ENGLISH)));

--- a/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactory.java
+++ b/junit-jupiter-engine/src/main/java/org/junit/jupiter/engine/extension/TimeoutInvocationFactory.java
@@ -67,7 +67,7 @@ class TimeoutInvocationFactory {
 		@Override
 		public void close() throws Exception {
 			executor.shutdown();
-			boolean terminated = executor.awaitTermination(5, TimeUnit.SECONDS);
+			var terminated = executor.awaitTermination(5, TimeUnit.SECONDS);
 			if (!terminated) {
 				executor.shutdownNow();
 				throw new JUnitException("Scheduled executor could not be stopped in an orderly manner");

--- a/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/ExpectedExceptionSupport.java
+++ b/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/ExpectedExceptionSupport.java
@@ -61,7 +61,7 @@ public class ExpectedExceptionSupport implements AfterEachCallback, TestExecutio
 
 	@Override
 	public void afterEach(ExtensionContext context) throws Exception {
-		boolean handled = getStore(context).computeIfAbsent(EXCEPTION_WAS_HANDLED, key -> false, Boolean.class);
+		var handled = getStore(context).computeIfAbsent(EXCEPTION_WAS_HANDLED, key -> false, Boolean.class);
 		if (!handled) {
 			this.support.afterEach(context);
 		}

--- a/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/TestRuleSupport.java
+++ b/junit-jupiter-migrationsupport/src/main/java/org/junit/jupiter/migrationsupport/rules/TestRuleSupport.java
@@ -60,7 +60,7 @@ class TestRuleSupport implements BeforeEachCallback, TestExecutionExceptionHandl
 	 */
 	@SuppressWarnings("JavadocReference")
 	private List<TestRuleAnnotatedMember> findRuleAnnotatedMembers(Object testInstance) {
-		List<TestRuleAnnotatedMember> result = new ArrayList<>();
+		var result = new ArrayList<TestRuleAnnotatedMember>();
 		// @formatter:off
 		// Instantiate rules from methods by calling them
 		findAnnotatedMethods(testInstance).stream()
@@ -96,7 +96,7 @@ class TestRuleSupport implements BeforeEachCallback, TestExecutionExceptionHandl
 
 	@Override
 	public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
-		int numRuleAnnotatedMembers = invokeAppropriateMethodOnRuleAnnotatedMembers(context, true,
+		var numRuleAnnotatedMembers = invokeAppropriateMethodOnRuleAnnotatedMembers(context, true,
 			advice -> advice.handleTestExecutionException(throwable));
 
 		// If no appropriate @Rule annotated members were discovered, we then

--- a/junit-jupiter-params/src/jmh/java/org/junit/jupiter/params/ParameterizedInvocationNameFormatterBenchmarks.java
+++ b/junit-jupiter-params/src/jmh/java/org/junit/jupiter/params/ParameterizedInvocationNameFormatterBenchmarks.java
@@ -54,7 +54,7 @@ public class ParameterizedInvocationNameFormatterBenchmarks {
 			new ParameterizedTestContext(TestCase.class, method,
 				requireNonNull(method.getAnnotation(ParameterizedTest.class))),
 			512);
-		for (int i = 0; i < argumentsList.size(); i++) {
+		for (var i = 0; i < argumentsList.size(); i++) {
 			Arguments arguments = argumentsList.get(i);
 			blackhole.consume(formatter.format(i, EvaluatedArgumentSet.allOf(arguments), false));
 		}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ArgumentCountValidator.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ArgumentCountValidator.java
@@ -43,9 +43,9 @@ class ArgumentCountValidator {
 			case DEFAULT, NONE -> {
 			}
 			case STRICT -> {
-				int consumedCount = this.declarationContext.getResolverFacade().determineConsumedArgumentCount(
+				var consumedCount = this.declarationContext.getResolverFacade().determineConsumedArgumentCount(
 					this.arguments);
-				int totalCount = this.arguments.getTotalLength();
+				var totalCount = this.arguments.getTotalLength();
 				Preconditions.condition(consumedCount == totalCount,
 					() -> wrongNumberOfArgumentsMessages("consumes", consumedCount, null, null));
 			}
@@ -66,7 +66,7 @@ class ArgumentCountValidator {
 
 	private String wrongNumberOfArgumentsMessages(String verb, int actualCount, @Nullable String parameterAdjective,
 			@Nullable String reason) {
-		int totalCount = this.arguments.getTotalLength();
+		var totalCount = this.arguments.getTotalLength();
 		return "Configuration error: @%s %s %s %s%s%s but there %s %s %s provided.%nNote: the provided arguments were %s".formatted(
 			this.declarationContext.getAnnotationName(), verb, actualCount,
 			parameterAdjective == null ? "" : parameterAdjective + " ",

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedInvocationNameFormatter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ParameterizedInvocationNameFormatter.java
@@ -25,7 +25,6 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -72,7 +71,7 @@ class ParameterizedInvocationNameFormatter {
 				declarationContext.getAnnotationName(),
 				declarationContext.getResolverFacade().getIndexedParameterDeclarations().getSourceElementDescription()));
 
-		int argumentMaxLength = extensionContext.getConfigurationParameter(ARGUMENT_MAX_LENGTH_KEY, Integer::parseInt) //
+		var argumentMaxLength = extensionContext.getConfigurationParameter(ARGUMENT_MAX_LENGTH_KEY, Integer::parseInt) //
 				.orElse(512);
 
 		return new ParameterizedInvocationNameFormatter(pattern, extensionContext.getDisplayName(), declarationContext,
@@ -118,7 +117,7 @@ class ParameterizedInvocationNameFormatter {
 	private PartialFormatter[] parse(String pattern, String displayName,
 			ParameterizedDeclarationContext<?> declarationContext, int argumentMaxLength) {
 
-		List<PartialFormatter> result = new ArrayList<>();
+		var result = new ArrayList<PartialFormatter>();
 		PartialFormatters formatters = createPartialFormatters(displayName, declarationContext, argumentMaxLength);
 		String unparsedSegment = pattern;
 
@@ -145,7 +144,7 @@ class ParameterizedInvocationNameFormatter {
 		}
 		PlaceholderPosition minimum = null;
 		for (String placeholder : formatters.placeholders()) {
-			int index = segment.indexOf(placeholder);
+			var index = segment.indexOf(placeholder);
 			if (index >= 0) {
 				if (index < formatters.minimumPlaceholderLength) {
 					return new PlaceholderPosition(index, placeholder);
@@ -194,7 +193,7 @@ class ParameterizedInvocationNameFormatter {
 		return argumentsPatternCache.computeIfAbsent(length, //
 			key -> {
 				StringJoiner sj = new StringJoiner(", ");
-				for (int i = 0; i < length; i++) {
+				for (var i = 0; i < length; i++) {
 					sj.add("{" + i + "}");
 				}
 				return sj.toString();
@@ -266,7 +265,7 @@ class ParameterizedInvocationNameFormatter {
 			Format[] formats = messageFormat.getFormatsByArgumentIndex();
 			@Nullable
 			Object[] result = Arrays.copyOf(arguments, Math.min(arguments.length, formats.length), Object[].class);
-			for (int i = 0; i < result.length; i++) {
+			for (var i = 0; i < result.length; i++) {
 				if (formats[i] == null) {
 					Object argument = arguments[i];
 					String prefix = "";
@@ -342,7 +341,7 @@ class ParameterizedInvocationNameFormatter {
 
 		void put(String placeholder, PartialFormatter formatter) {
 			formattersByPlaceholder.put(placeholder, formatter);
-			int newPlaceholderLength = placeholder.length();
+			var newPlaceholderLength = placeholder.length();
 			if (newPlaceholderLength < minimumPlaceholderLength) {
 				minimumPlaceholderLength = newPlaceholderLength;
 			}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/QuoteUtils.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/QuoteUtils.java
@@ -27,7 +27,7 @@ final class QuoteUtils {
 		}
 		StringBuilder builder = new StringBuilder();
 		builder.append('"');
-		for (int i = 0; i < text.length(); i++) {
+		for (var i = 0; i < text.length(); i++) {
 			builder.append(escape(text.charAt(i), true));
 		}
 		builder.append('"');

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ResolverFacade.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/ResolverFacade.java
@@ -70,13 +70,13 @@ class ResolverFacade {
 	static ResolverFacade create(Class<?> clazz, List<Field> fields) {
 		Preconditions.notEmpty(fields, "Fields must not be empty");
 
-		NavigableMap<Integer, List<FieldParameterDeclaration>> allIndexedParameters = new TreeMap<>();
-		Set<FieldParameterDeclaration> aggregatorParameters = new LinkedHashSet<>();
+		var allIndexedParameters = new TreeMap<Integer, List<FieldParameterDeclaration>>();
+		var aggregatorParameters = new LinkedHashSet<FieldParameterDeclaration>();
 
 		for (Field field : fields) {
 			Parameter annotation = findAnnotation(field, Parameter.class) //
 					.orElseThrow(() -> new JUnitException("No @Parameter annotation present"));
-			int index = annotation.value();
+			var index = annotation.value();
 
 			FieldParameterDeclaration declaration = new FieldParameterDeclaration(field, annotation.value());
 			if (declaration.isAggregator()) {
@@ -135,9 +135,9 @@ class ResolverFacade {
 
 	private static ResolverFacade create(Executable executable, Annotation annotation, int indexOffset,
 			java.lang.reflect.Parameter[] parameters) {
-		NavigableMap<Integer, ExecutableParameterDeclaration> indexedParameters = new TreeMap<>();
-		NavigableMap<Integer, ExecutableParameterDeclaration> aggregatorParameters = new TreeMap<>();
-		for (int index = indexOffset; index < parameters.length; index++) {
+		var indexedParameters = new TreeMap<Integer, ExecutableParameterDeclaration>();
+		var aggregatorParameters = new TreeMap<Integer, ExecutableParameterDeclaration>();
+		for (var index = indexOffset; index < parameters.length; index++) {
 			ExecutableParameterDeclaration declaration = new ExecutableParameterDeclaration(parameters[index], index,
 				indexOffset);
 			if (declaration.isAggregator()) {
@@ -187,7 +187,7 @@ class ResolverFacade {
 	}
 
 	boolean isSupportedParameter(ParameterContext parameterContext, EvaluatedArgumentSet arguments) {
-		int index = toLogicalIndex(parameterContext);
+		var index = toLogicalIndex(parameterContext);
 		if (this.indexedParameterDeclarations.get(index).isPresent()) {
 			return index < arguments.getConsumedLength();
 		}
@@ -242,7 +242,7 @@ class ResolverFacade {
 		ResolverFacade originalResolverFacade = this;
 		ResolverFacade lifecycleMethodResolverFacade = create(method, annotation);
 
-		Map<ParameterDeclaration, ResolvableParameterDeclaration> parameterDeclarationMapping = new HashMap<>();
+		var parameterDeclarationMapping = new HashMap<ParameterDeclaration, ResolvableParameterDeclaration>();
 		List<String> errors = validateLifecycleMethodParameters(originalResolverFacade, lifecycleMethodResolverFacade,
 			parameterDeclarationMapping);
 
@@ -264,7 +264,7 @@ class ResolverFacade {
 	Object resolve(ParameterContext parameterContext, ExtensionContext extensionContext, EvaluatedArgumentSet arguments,
 			int invocationIndex, ResolutionCache resolutionCache) {
 
-		int parameterIndex = toLogicalIndex(parameterContext);
+		var parameterIndex = toLogicalIndex(parameterContext);
 		ResolvableParameterDeclaration declaration = findDeclaration(parameterIndex) //
 				.orElseThrow(
 					() -> new ParameterResolutionException("Parameter index out of bounds: " + parameterIndex));
@@ -328,7 +328,7 @@ class ResolverFacade {
 	}
 
 	private int toLogicalIndex(ParameterContext parameterContext) {
-		int index = parameterContext.getIndex() - this.parameterIndexOffset;
+		var index = parameterContext.getIndex() - this.parameterIndexOffset;
 		Preconditions.condition(index >= 0, () -> "Parameter index must be greater than or equal to zero");
 		return index;
 	}
@@ -337,7 +337,7 @@ class ResolverFacade {
 			NavigableMap<Integer, List<FieldParameterDeclaration>> indexedParameters,
 			Set<FieldParameterDeclaration> aggregatorParameters) {
 
-		List<String> errors = new ArrayList<>();
+		var errors = new ArrayList<String>();
 		validateIndexedParameters(indexedParameters, errors);
 		validateAggregatorParameters(aggregatorParameters, errors);
 
@@ -349,8 +349,8 @@ class ResolverFacade {
 			ResolverFacade lifecycleMethodResolverFacade,
 			Map<ParameterDeclaration, ResolvableParameterDeclaration> parameterDeclarationMapping) {
 		List<ParameterDeclaration> actualDeclarations = lifecycleMethodResolverFacade.indexedParameterDeclarations.getAll();
-		List<String> errors = new ArrayList<>();
-		for (int parameterIndex = 0; parameterIndex < actualDeclarations.size(); parameterIndex++) {
+		var errors = new ArrayList<String>();
+		for (var parameterIndex = 0; parameterIndex < actualDeclarations.size(); parameterIndex++) {
 			ParameterDeclaration actualDeclaration = actualDeclarations.get(parameterIndex);
 			ResolvableParameterDeclaration originalDeclaration = originalResolverFacade.indexedParameterDeclarations.declarationsByIndex //
 					.get(parameterIndex);
@@ -401,7 +401,7 @@ class ResolverFacade {
 		indexedParameters.forEach(
 			(index, declarations) -> validateIndexedParameterDeclarations(index, declarations, errors));
 
-		for (int index = 0; index <= indexedParameters.lastKey(); index++) {
+		for (var index = 0; index <= indexedParameters.lastKey(); index++) {
 			if (!indexedParameters.containsKey(index)) {
 				errors.add("no field annotated with @Parameter(%d) declared".formatted(index));
 			}

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/JavaTimeArgumentConverter.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/converter/JavaTimeArgumentConverter.java
@@ -36,7 +36,7 @@ class JavaTimeArgumentConverter extends AnnotationBasedArgumentConverter<JavaTim
 
 	private static final Map<Class<?>, TemporalQuery<?>> TEMPORAL_QUERIES;
 	static {
-		Map<Class<?>, TemporalQuery<?>> queries = new LinkedHashMap<>();
+		var queries = new LinkedHashMap<Class<?>, TemporalQuery<?>>();
 		queries.put(ChronoLocalDate.class, ChronoLocalDate::from);
 		queries.put(ChronoLocalDateTime.class, ChronoLocalDateTime::from);
 		queries.put(ChronoZonedDateTime.class, ChronoZonedDateTime::from);

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvArgumentsProvider.java
@@ -38,10 +38,10 @@ class CsvArgumentsProvider extends AnnotationBasedArgumentsProvider<CsvSource> {
 
 		CsvReaderFactory.validate(csvSource);
 
-		List<Arguments> arguments = new ArrayList<>();
+		var arguments = new ArrayList<Arguments>();
 
 		try (var reader = CsvReaderFactory.createReaderFor(csvSource, getData(csvSource))) {
-			boolean useHeadersInDisplayName = csvSource.useHeadersInDisplayName();
+			var useHeadersInDisplayName = csvSource.useHeadersInDisplayName();
 			for (CsvRecord record : reader) {
 				arguments.add(processCsvRecord(record, useHeadersInDisplayName));
 			}
@@ -62,8 +62,8 @@ class CsvArgumentsProvider extends AnnotationBasedArgumentsProvider<CsvSource> {
 			return csvSource.textBlock();
 		}
 		else {
-			for (int i = 0; i < values.length; i++) {
-				int finalI = i;
+			for (var i = 0; i < values.length; i++) {
+				var finalI = i;
 				Preconditions.notBlank(values[i],
 					() -> "CSV record at index %d must not be blank".formatted(finalI + 1));
 			}
@@ -87,7 +87,7 @@ class CsvArgumentsProvider extends AnnotationBasedArgumentsProvider<CsvSource> {
 		@Nullable
 		Object[] arguments = new Object[fields.size()];
 
-		for (int i = 0; i < fields.size(); i++) {
+		for (var i = 0; i < fields.size(); i++) {
 			Object argument = resolveNullMarker(fields.get(i));
 			if (useHeadersInDisplayName) {
 				String header = resolveNullMarker(headers.get(i));

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvFileArgumentsProvider.java
@@ -78,7 +78,7 @@ class CsvFileArgumentsProvider extends AnnotationBasedArgumentsProvider<CsvFileS
 
 	private static Stream<Arguments> toStream(CsvReader<? extends CsvRecord> reader, CsvFileSource csvFileSource) {
 		var spliterator = CsvExceptionHandlingSpliterator.delegatingTo(reader.spliterator(), csvFileSource);
-		boolean useHeadersInDisplayName = csvFileSource.useHeadersInDisplayName();
+		var useHeadersInDisplayName = csvFileSource.useHeadersInDisplayName();
 		// @formatter:off
 		return StreamSupport.stream(spliterator, false)
 				.skip(csvFileSource.numLinesToSkip())

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvReaderFactory.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/CsvReaderFactory.java
@@ -149,7 +149,7 @@ class CsvReaderFactory {
 	}
 
 	private static boolean stringValuesUnique(Object... values) {
-		long uniqueCount = Stream.of(values).map(String::valueOf).distinct().count();
+		var uniqueCount = Stream.of(values).map(String::valueOf).distinct().count();
 		return uniqueCount == values.length;
 	}
 

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodArgumentsProvider.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/provider/MethodArgumentsProvider.java
@@ -90,11 +90,11 @@ class MethodArgumentsProvider extends AnnotationBasedArgumentsProvider<MethodSou
 		if (factoryMethodName.contains("#")) {
 			return true;
 		}
-		int indexOfFirstDot = factoryMethodName.indexOf('.');
+		var indexOfFirstDot = factoryMethodName.indexOf('.');
 		if (indexOfFirstDot == -1) {
 			return false;
 		}
-		int indexOfLastOpeningParenthesis = factoryMethodName.lastIndexOf('(');
+		var indexOfLastOpeningParenthesis = factoryMethodName.lastIndexOf('(');
 		if (indexOfLastOpeningParenthesis > 0) {
 			// Exclude simple/local method names with parameters
 			return indexOfFirstDot < indexOfLastOpeningParenthesis;
@@ -122,7 +122,7 @@ class MethodArgumentsProvider extends AnnotationBasedArgumentsProvider<MethodSou
 			return factoryMethod;
 		}
 
-		boolean explicitParameterListSpecified = //
+		var explicitParameterListSpecified = //
 			StringUtils.isNotBlank(methodParameters) || fullyQualifiedMethodName.endsWith("()");
 
 		// If we didn't find an exact match but an explicit parameter list was specified,

--- a/junit-jupiter-params/src/main/java/org/junit/jupiter/params/support/AnnotationConsumerInitializer.java
+++ b/junit-jupiter-params/src/main/java/org/junit/jupiter/params/support/AnnotationConsumerInitializer.java
@@ -82,7 +82,7 @@ public final class AnnotationConsumerInitializer {
 
 	@SuppressWarnings("unchecked")
 	private static Class<? extends Annotation> getAnnotationType(Method method) {
-		int annotationIndex = annotationConsumingMethodSignatures.stream() //
+		var annotationIndex = annotationConsumingMethodSignatures.stream() //
 				.filter(signature -> signature.isMatchingWith(method)) //
 				.findFirst() //
 				.map(AnnotationConsumingMethodSignature::annotationParameterIndex) //

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/logging/LoggerFactory.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/logging/LoggerFactory.java
@@ -143,7 +143,7 @@ public final class LoggerFactory {
 		}
 
 		private void log(Level level, @Nullable Throwable throwable, Supplier<String> messageSupplier) {
-			boolean loggable = this.julLogger.isLoggable(level);
+			var loggable = this.julLogger.isLoggable(level);
 			if (loggable || !listeners.isEmpty()) {
 				LogRecord logRecord = createLogRecord(level, throwable, messageSupplier.get());
 				if (loggable) {
@@ -156,7 +156,7 @@ public final class LoggerFactory {
 		private LogRecord createLogRecord(Level level, @Nullable Throwable throwable, String message) {
 			String sourceClassName = null;
 			String sourceMethodName = null;
-			boolean found = false;
+			var found = false;
 			for (StackTraceElement element : new Throwable().getStackTrace()) {
 				String className = element.getClassName();
 				if (FQCN.equals(className)) {

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/StringToBooleanConverter.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/support/conversion/StringToBooleanConverter.java
@@ -21,7 +21,7 @@ class StringToBooleanConverter implements StringToObjectConverter {
 
 	@Override
 	public Object convert(String source, Class<?> targetType) {
-		boolean isTrue = "true".equalsIgnoreCase(source);
+		var isTrue = "true".equalsIgnoreCase(source);
 		Preconditions.condition(isTrue || "false".equalsIgnoreCase(source),
 			() -> "String must be 'true' or 'false' (ignoring case): " + source);
 		return isTrue;

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/AnnotationUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/AnnotationUtils.java
@@ -139,7 +139,7 @@ public final class AnnotationUtils {
 	public static <A extends Annotation> Optional<A> findAnnotation(@Nullable AnnotatedElement element,
 			Class<A> annotationType) {
 		Preconditions.notNull(annotationType, "annotationType must not be null");
-		boolean inherited = annotationType.isAnnotationPresent(Inherited.class);
+		var inherited = annotationType.isAnnotationPresent(Inherited.class);
 		return findAnnotation(element, annotationType, inherited, new HashSet<>());
 	}
 
@@ -284,7 +284,7 @@ public final class AnnotationUtils {
 		Repeatable repeatable = annotationType.getAnnotation(Repeatable.class);
 		Preconditions.notNull(repeatable, () -> annotationType.getName() + " must be @Repeatable");
 		Class<? extends Annotation> containerType = repeatable.value();
-		boolean inherited = containerType.isAnnotationPresent(Inherited.class);
+		var inherited = containerType.isAnnotationPresent(Inherited.class);
 
 		// Short circuit the search algorithm.
 		if (element == null) {

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClassNamePatternFilterUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ClassNamePatternFilterUtils.java
@@ -110,7 +110,7 @@ public class ClassNamePatternFilterUtils {
 
 		List<Pattern> patternList = convertToRegularExpressions(patterns);
 		return object -> {
-			boolean isMatchingAnyPattern = patternList.stream().anyMatch(
+			var isMatchingAnyPattern = patternList.stream().anyMatch(
 				pattern -> pattern.matcher(classNameProvider.apply(object)).matches());
 			return (type == FilterType.INCLUDE) == isMatchingAnyPattern;
 		};

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/CloseablePath.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/CloseablePath.java
@@ -56,7 +56,7 @@ final class CloseablePath implements Closeable {
 		if (JAR_URI_SCHEME.equals(uri.getScheme())) {
 			// Parsing: jar:<url>!/[<entry>], see java.net.JarURLConnection
 			String uriString = uri.toString();
-			int lastJarUriSeparator = uriString.lastIndexOf(JAR_URI_SEPARATOR);
+			var lastJarUriSeparator = uriString.lastIndexOf(JAR_URI_SEPARATOR);
 			String jarUri = uriString.substring(0, lastJarUriSeparator);
 			String jarEntry = uriString.substring(lastJarUriSeparator + 1);
 			return createForJarFileSystem(new URI(jarUri), fileSystem -> fileSystem.getPath(jarEntry),

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/DefaultClasspathScanner.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/DefaultClasspathScanner.java
@@ -26,7 +26,6 @@ import java.util.Collection;
 import java.util.Enumeration;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -130,7 +129,7 @@ class DefaultClasspathScanner implements ClasspathScanner {
 	}
 
 	private List<Class<?>> findClassesForUri(URI baseUri, String basePackageName, ClassFilter classFilter) {
-		List<Class<?>> classes = new ArrayList<>();
+		var classes = new ArrayList<Class<?>>();
 		// @formatter:off
 		walkFilesForUri(baseUri, SearchPathUtils::isClassOrSourceFile,
 				(baseDir, file) ->
@@ -154,7 +153,7 @@ class DefaultClasspathScanner implements ClasspathScanner {
 	}
 
 	private List<Resource> findResourcesForUri(URI baseUri, String basePackageName, ResourceFilter resourceFilter) {
-		List<Resource> resources = new ArrayList<>();
+		var resources = new ArrayList<Resource>();
 		// @formatter:off
 		walkFilesForUri(baseUri, SearchPathUtils::isResourceFile,
 				(baseDir, file) ->
@@ -300,7 +299,7 @@ class DefaultClasspathScanner implements ClasspathScanner {
 	}
 
 	private List<URI> getRootUrisForPackageNameOnClassPathAndModulePath(String basePackageName) {
-		Set<URI> uriSet = new LinkedHashSet<>(getRootUrisForPackage(basePackageName));
+		var uriSet = new LinkedHashSet<URI>(getRootUrisForPackage(basePackageName));
 		if (!basePackageName.isEmpty() && !basePackageName.endsWith(PACKAGE_SEPARATOR_STRING)) {
 			getRootUrisForPackage(basePackageName + PACKAGE_SEPARATOR_STRING).stream() //
 					.map(DefaultClasspathScanner::removeTrailingClasspathResourcePathSeparator) //
@@ -325,7 +324,7 @@ class DefaultClasspathScanner implements ClasspathScanner {
 	}
 
 	private List<URI> getRootUrisForPackage(String basePackageName) {
-		List<URI> uris = new ArrayList<>();
+		var uris = new ArrayList<URI>();
 		try {
 			Enumeration<URL> resources = getClassLoader().getResources(packagePath(basePackageName));
 			while (resources.hasMoreElements()) {

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ExceptionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ExceptionUtils.java
@@ -18,10 +18,8 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Deque;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Predicate;
 
 import org.apiguardian.api.API;
@@ -128,12 +126,12 @@ public final class ExceptionUtils {
 		Preconditions.notNull(classNames, "List of class names must not be null");
 
 		List<StackTraceElement> stackTrace = Arrays.asList(throwable.getStackTrace());
-		List<StackTraceElement> prunedStackTrace = new ArrayList<>();
-		List<StackTraceElement> junitStartStackTrace = new ArrayList<>(0);
+		var prunedStackTrace = new ArrayList<StackTraceElement>();
+		var junitStartStackTrace = new ArrayList<StackTraceElement>(0);
 
 		Collections.reverse(stackTrace);
 
-		for (int i = 0; i < stackTrace.size(); i++) {
+		for (var i = 0; i < stackTrace.size(); i++) {
 			StackTraceElement element = stackTrace.get(i);
 			String className = element.getClassName();
 
@@ -188,13 +186,13 @@ public final class ExceptionUtils {
 	public static List<Throwable> findNestedThrowables(Throwable rootThrowable) {
 		Preconditions.notNull(rootThrowable, "Throwable must not be null");
 
-		Set<Throwable> visited = new LinkedHashSet<>();
-		Deque<Throwable> toVisit = new ArrayDeque<>();
+		var visited = new LinkedHashSet<Throwable>();
+		var toVisit = new ArrayDeque<Throwable>();
 		toVisit.add(rootThrowable);
 
 		while (!toVisit.isEmpty()) {
 			Throwable current = toVisit.remove();
-			boolean isFirstVisit = visited.add(current);
+			var isFirstVisit = visited.add(current);
 			if (isFirstVisit) {
 				Throwable cause = current.getCause();
 				if (cause != null) {

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/KotlinReflectionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/KotlinReflectionUtils.java
@@ -68,7 +68,7 @@ public class KotlinReflectionUtils {
 	@API(status = INTERNAL, since = "6.0")
 	public static boolean isKotlinSuspendingFunction(Method method) {
 		if (!method.isSynthetic() && kotlinCoroutineContinuation != null && isKotlinType(method.getDeclaringClass())) {
-			int parameterCount = method.getParameterCount();
+			var parameterCount = method.getParameterCount();
 			return parameterCount > 0 //
 					&& method.getParameterTypes()[parameterCount - 1] == kotlinCoroutineContinuation;
 		}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/KotlinSuspendingFunctionUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/KotlinSuspendingFunctionUtils.java
@@ -93,8 +93,8 @@ class KotlinSuspendingFunctionUtils {
 
 	private static Map<KParameter, @Nullable Object> toArgumentMap(@Nullable Object target, @Nullable Object[] args,
 			KFunction<?> function) {
-		Map<KParameter, @Nullable Object> arguments = new HashMap<>(args.length + 1);
-		int index = 0;
+		var arguments = new HashMap<KParameter, @Nullable Object>(args.length + 1);
+		var index = 0;
 		for (KParameter parameter : function.getParameters()) {
 			switch (parameter.getKind()) {
 				case INSTANCE -> arguments.put(parameter, target);

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ModuleUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ModuleUtils.java
@@ -209,7 +209,7 @@ public class ModuleUtils {
 	private static List<Class<?>> scan(Set<ModuleReference> references, ClassFilter filter, ClassLoader loader) {
 		logger.debug(() -> "Scanning " + references.size() + " module references: " + references);
 		ModuleReferenceClassScanner scanner = new ModuleReferenceClassScanner(filter, loader);
-		List<Class<?>> classes = new ArrayList<>();
+		var classes = new ArrayList<Class<?>>();
 		for (ModuleReference reference : references) {
 			classes.addAll(scanner.scan(reference));
 		}
@@ -224,7 +224,7 @@ public class ModuleUtils {
 	private static List<Resource> scan(Set<ModuleReference> references, ResourceFilter filter, ClassLoader loader) {
 		logger.debug(() -> "Scanning " + references.size() + " module references: " + references);
 		ModuleReferenceResourceScanner scanner = new ModuleReferenceResourceScanner(filter, loader);
-		List<Resource> resources = new ArrayList<>();
+		var resources = new ArrayList<Resource>();
 		for (ModuleReference reference : references) {
 			resources.addAll(scanner.scan(reference));
 		}

--- a/junit-platform-commons/src/main/java/org/junit/platform/commons/util/SearchPathUtils.java
+++ b/junit-platform-commons/src/main/java/org/junit/platform/commons/util/SearchPathUtils.java
@@ -67,7 +67,7 @@ class SearchPathUtils {
 	}
 
 	private static String removeExtension(String fileName) {
-		int lastDot = fileName.lastIndexOf(FILE_NAME_EXTENSION_SEPARATOR_CHAR);
+		var lastDot = fileName.lastIndexOf(FILE_NAME_EXTENSION_SEPARATOR_CHAR);
 		if (lastDot < 0) {
 			throw new JUnitException("Expected file name with file extension, but got: " + fileName);
 		}

--- a/junit-platform-commons/src/testFixtures/java/org/junit/platform/commons/test/ConcurrencyTestingUtils.java
+++ b/junit-platform-commons/src/testFixtures/java/org/junit/platform/commons/test/ConcurrencyTestingUtils.java
@@ -38,8 +38,8 @@ public class ConcurrencyTestingUtils {
 		ExecutorService executorService = Executors.newFixedThreadPool(threads);
 		try {
 			CountDownLatch latch = new CountDownLatch(threads);
-			List<CompletableFuture<T>> futures = new ArrayList<>();
-			for (int i = 0; i < threads; i++) {
+			var futures = new ArrayList<CompletableFuture<T>>();
+			for (var i = 0; i < threads; i++) {
 				futures.add(CompletableFuture.supplyAsync(() -> {
 					try {
 						latch.countDown();
@@ -55,7 +55,7 @@ public class ConcurrencyTestingUtils {
 					}
 				}, executorService));
 			}
-			List<T> list = new ArrayList<>();
+			var list = new ArrayList<T>();
 			for (CompletableFuture<T> future : futures) {
 				list.add(future.get(5, SECONDS));
 			}

--- a/junit-platform-console/src/main/java/org/junit/platform/console/command/DiscoveryRequestCreator.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/command/DiscoveryRequestCreator.java
@@ -91,7 +91,7 @@ class DiscoveryRequestCreator {
 		var selectedClasspathEntries = Preconditions.notNull(options.getSelectedClasspathEntries(),
 			() -> "No classpath entries selected");
 		if (selectedClasspathEntries.isEmpty()) {
-			Set<Path> rootDirs = new LinkedHashSet<>(ReflectionUtils.getAllClasspathRootDirectories());
+			var rootDirs = new LinkedHashSet<Path>(ReflectionUtils.getAllClasspathRootDirectories());
 			rootDirs.addAll(options.getAdditionalClasspathEntries());
 			return rootDirs;
 		}
@@ -99,8 +99,8 @@ class DiscoveryRequestCreator {
 	}
 
 	private static Set<Path> validateAndLogInvalidRoots(Set<Path> roots) {
-		LinkedHashSet<Path> valid = new LinkedHashSet<>();
-		HashSet<Path> seen = new HashSet<>();
+		var valid = new LinkedHashSet<Path>();
+		var seen = new HashSet<Path>();
 
 		for (Path root : roots) {
 			if (!seen.add(root)) {

--- a/junit-platform-console/src/main/java/org/junit/platform/console/command/ExecuteTestsCommand.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/command/ExecuteTestsCommand.java
@@ -84,7 +84,7 @@ class ExecuteTestsCommand extends BaseCommand<TestExecutionSummary> implements C
 	@Override
 	public int getExitCode() {
 		TestExecutionSummary executionResult = commandSpec.commandLine().getExecutionResult();
-		boolean failIfNoTests = getReportingOptions().map(it -> it.failIfNoTests).orElse(false);
+		var failIfNoTests = getReportingOptions().map(it -> it.failIfNoTests).orElse(false);
 		if (failIfNoTests && executionResult.getTestsFoundCount() == 0) {
 			return NO_TESTS_FOUND;
 		}

--- a/junit-platform-console/src/main/java/org/junit/platform/console/command/MainCommand.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/command/MainCommand.java
@@ -99,7 +99,7 @@ class MainCommand implements Runnable, IExitCodeGenerator {
 			@SuppressWarnings("OptionalUsedAsFieldOrParameterType") Optional<OutputStreamConfig> outputStreamConfig) {
 		BaseCommand.initialize(commandLine);
 		outputStreamConfig.ifPresent(it -> it.applyTo(commandLine));
-		int exitCode = commandLine.execute(args);
+		var exitCode = commandLine.execute(args);
 		return CommandResult.create(exitCode, getLikelyExecutedCommand(commandLine).getExecutionResult());
 	}
 

--- a/junit-platform-console/src/main/java/org/junit/platform/console/options/TestDiscoveryOptions.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/options/TestDiscoveryOptions.java
@@ -201,7 +201,7 @@ public class TestDiscoveryOptions {
 	}
 
 	public List<DiscoverySelector> getExplicitSelectors() {
-		List<DiscoverySelector> selectors = new ArrayList<>();
+		var selectors = new ArrayList<DiscoverySelector>();
 		selectors.addAll(getSelectedUniqueIds());
 		selectors.addAll(getSelectedUris());
 		selectors.addAll(getSelectedFiles());

--- a/junit-platform-console/src/main/java/org/junit/platform/console/output/ColorPalette.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/output/ColorPalette.java
@@ -42,7 +42,7 @@ public class ColorPalette {
 
 	// https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
 	private static Map<Style, String> defaultPalette() {
-		Map<Style, String> colorsToAnsiSequences = new EnumMap<>(Style.class);
+		var colorsToAnsiSequences = new EnumMap<Style, String>(Style.class);
 		colorsToAnsiSequences.put(Style.NONE, "0");
 		colorsToAnsiSequences.put(Style.SUCCESSFUL, "32");
 		colorsToAnsiSequences.put(Style.ABORTED, "33");
@@ -56,7 +56,7 @@ public class ColorPalette {
 	}
 
 	private static Map<Style, String> singleColorPalette() {
-		Map<Style, String> colorsToAnsiSequences = new EnumMap<>(Style.class);
+		var colorsToAnsiSequences = new EnumMap<Style, String>(Style.class);
 		colorsToAnsiSequences.put(Style.NONE, "0");
 		colorsToAnsiSequences.put(Style.SUCCESSFUL, "1");
 		colorsToAnsiSequences.put(Style.ABORTED, "4");

--- a/junit-platform-console/src/main/java/org/junit/platform/console/output/TestFeedPrintingListener.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/output/TestFeedPrintingListener.java
@@ -96,9 +96,9 @@ public class TestFeedPrintingListener implements DetailsPrintingListener {
 	}
 
 	private List<String> collectDisplayNames(UniqueId uniqueId) {
-		int size = uniqueId.getSegments().size();
-		List<String> displayNames = new ArrayList<>(size);
-		for (int i = 0; i < size; i++) {
+		var size = uniqueId.getSegments().size();
+		var displayNames = new ArrayList<String>(size);
+		for (var i = 0; i < size; i++) {
 			displayNames.add(0, requireNonNull(testPlan).getTestIdentifier(uniqueId).getDisplayName());
 			if (i < size - 1) {
 				uniqueId = uniqueId.removeLastSegment();

--- a/junit-platform-console/src/main/java/org/junit/platform/console/output/TreeNode.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/output/TreeNode.java
@@ -97,7 +97,7 @@ class TreeNode {
 
 	@SuppressWarnings("DataFlowIssue")
 	static String createCaption(String displayName) {
-		boolean normal = displayName.length() <= 80;
+		var normal = displayName.length() <= 80;
 		String caption = normal ? displayName : displayName.substring(0, 80) + "...";
 		String whites = StringUtils.replaceWhitespaceCharacters(caption, " ");
 		return StringUtils.replaceIsoControlCharacters(whites, ".");

--- a/junit-platform-console/src/main/java/org/junit/platform/console/output/TreePrinter.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/output/TreePrinter.java
@@ -79,7 +79,7 @@ class TreePrinter {
 			out.print(" ");
 			out.print(duration);
 		}
-		boolean nodeIsBeingListed = node.duration == 0 && node.result().isEmpty() && node.reason().isEmpty();
+		var nodeIsBeingListed = node.duration == 0 && node.result().isEmpty() && node.reason().isEmpty();
 		if (!nodeIsBeingListed) {
 			out.print(" ");
 			out.print(icon);
@@ -166,7 +166,7 @@ class TreePrinter {
 		out.print(" ");
 		out.print(color(style, lines[0]));
 		if (lines.length > 1) {
-			for (int i = 1; i < lines.length; i++) {
+			for (var i = 1; i < lines.length; i++) {
 				out.println();
 				out.print(indent);
 				if (StringUtils.isNotBlank(lines[i])) {

--- a/junit-platform-console/src/main/java/org/junit/platform/console/output/VerboseTreePrintingListener.java
+++ b/junit-platform-console/src/main/java/org/junit/platform/console/output/VerboseTreePrintingListener.java
@@ -54,7 +54,7 @@ public class VerboseTreePrintingListener implements DetailsPrintingListener {
 		this.verticals[1] = ""; // synthetic root "/" level
 		this.verticals[2] = ""; // "engine" level
 
-		for (int i = 3; i < verticals.length; i++) {
+		for (var i = 3; i < verticals.length; i++) {
 			verticals[i] = verticals[i - 1] + theme.vertical();
 		}
 	}
@@ -76,7 +76,7 @@ public class VerboseTreePrintingListener implements DetailsPrintingListener {
 	}
 
 	private void printNumberOfTests(TestPlan testPlan, String prefix) {
-		long tests = testPlan.countTestIdentifiers(TestIdentifier::isTest);
+		var tests = testPlan.countTestIdentifiers(TestIdentifier::isTest);
 		printf(NONE, "%s", prefix);
 		printf(Style.TEST, "%d%n", tests);
 	}
@@ -189,7 +189,7 @@ public class VerboseTreePrintingListener implements DetailsPrintingListener {
 		printf(style, "%s", lines[0]);
 		if (lines.length > 1) {
 			String delimiter = System.lineSeparator() + verticals + (detailFormat + "    ").formatted("");
-			for (int i = 1; i < lines.length; i++) {
+			for (var i = 1; i < lines.length; i++) {
 				printf(NONE, "%s", delimiter);
 				printf(style, "%s", lines[i]);
 			}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/TestDescriptor.java
@@ -138,7 +138,7 @@ public interface TestDescriptor {
 			return Collections.emptySet();
 		}
 		TestDescriptor parent = getParent().get();
-		Set<TestDescriptor> ancestors = new LinkedHashSet<>();
+		var ancestors = new LinkedHashSet<TestDescriptor>();
 		ancestors.add(parent);
 		// Need to recurse?
 		if (parent.getParent().isPresent()) {
@@ -159,7 +159,7 @@ public interface TestDescriptor {
 	 * @see #getChildren()
 	 */
 	default Set<? extends TestDescriptor> getDescendants() {
-		Set<TestDescriptor> descendants = new LinkedHashSet<>();
+		var descendants = new LinkedHashSet<TestDescriptor>();
 		descendants.addAll(getChildren());
 		for (TestDescriptor child : getChildren()) {
 			descendants.addAll(child.getDescendants());
@@ -213,7 +213,7 @@ public interface TestDescriptor {
 		Preconditions.notNull(suggestedOrder, "orderer may not return null");
 
 		Set<? extends TestDescriptor> orderedChildren = new LinkedHashSet<>(suggestedOrder);
-		boolean unmodified = originalChildren.equals(orderedChildren);
+		var unmodified = originalChildren.equals(orderedChildren);
 		Preconditions.condition(unmodified && originalChildren.size() == suggestedOrder.size(),
 			"orderer may not add or remove test descriptors");
 

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueId.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueId.java
@@ -161,7 +161,7 @@ public final class UniqueId implements Cloneable, Serializable {
 	@API(status = STABLE, since = "1.1")
 	public UniqueId append(Segment segment) {
 		Preconditions.notNull(segment, "segment must not be null");
-		List<Segment> baseSegments = new ArrayList<>(this.segments.size() + 1);
+		var baseSegments = new ArrayList<Segment>(this.segments.size() + 1);
 		baseSegments.addAll(this.segments);
 		baseSegments.add(segment);
 		return new UniqueId(this.uniqueIdFormat, baseSegments);
@@ -196,8 +196,8 @@ public final class UniqueId implements Cloneable, Serializable {
 	@API(status = STABLE, since = "1.1")
 	public boolean hasPrefix(UniqueId potentialPrefix) {
 		Preconditions.notNull(potentialPrefix, "potentialPrefix must not be null");
-		int size = this.segments.size();
-		int prefixSize = potentialPrefix.segments.size();
+		var size = this.segments.size();
+		var prefixSize = potentialPrefix.segments.size();
 		return size >= prefixSize && this.segments.subList(0, prefixSize).equals(potentialPrefix.segments);
 	}
 
@@ -249,7 +249,7 @@ public final class UniqueId implements Cloneable, Serializable {
 
 	@Override
 	public int hashCode() {
-		int value = this.hashCode;
+		var value = this.hashCode;
 		if (value == 0) {
 			value = this.segments.hashCode();
 			if (value == 0) {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueIdFormat.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/UniqueIdFormat.java
@@ -132,8 +132,8 @@ class UniqueIdFormat implements Serializable {
 
 	private String encode(String s) {
 		StringBuilder builder = new StringBuilder(s.length());
-		for (int i = 0; i < s.length(); i++) {
-			char c = s.charAt(i);
+		for (var i = 0; i < s.length(); i++) {
+			var c = s.charAt(i);
 			String value = encodedCharacterMap.get(c);
 			if (value == null) {
 				builder.append(c);

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClasspathResourceSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/ClasspathResourceSelector.java
@@ -65,7 +65,7 @@ public final class ClasspathResourceSelector implements DiscoverySelector {
 	private @Nullable Set<Resource> resources;
 
 	ClasspathResourceSelector(String classpathResourceName, @Nullable FilePosition position) {
-		boolean startsWithSlash = classpathResourceName.startsWith("/");
+		var startsWithSlash = classpathResourceName.startsWith("/");
 		this.classpathResourceName = (startsWithSlash ? classpathResourceName.substring(1) : classpathResourceName);
 		Preconditions.notBlank(this.classpathResourceName,
 			"classpath resource name must not be blank after removing leading slash");

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectorIdentifierParsers.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/DiscoverySelectorIdentifierParsers.java
@@ -68,7 +68,7 @@ class DiscoverySelectorIdentifierParsers {
 		private final Map<String, DiscoverySelectorIdentifierParser> parsersByPrefix;
 
 		Singleton() {
-			Map<String, DiscoverySelectorIdentifierParser> parsersByPrefix = new HashMap<>();
+			var parsersByPrefix = new HashMap<String, DiscoverySelectorIdentifierParser>();
 			Iterable<DiscoverySelectorIdentifierParser> loadedParsers = ServiceLoader.load(
 				DiscoverySelectorIdentifierParser.class, ClassLoaderUtils.getDefaultClassLoader());
 			for (DiscoverySelectorIdentifierParser parser : loadedParsers) {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/IterationSelector.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/discovery/IterationSelector.java
@@ -19,7 +19,6 @@ import static org.apiguardian.api.API.Status.MAINTAINED;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.SortedSet;
@@ -122,7 +121,7 @@ public final class IterationSelector implements DiscoverySelector {
 			}
 		}
 
-		List<Range> ranges = new ArrayList<>();
+		var ranges = new ArrayList<Range>();
 		Range current = new Range(this.iterationIndices.first());
 		ranges.add(current);
 		for (int n : this.iterationIndices.tailSet(current.start + 1)) {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptor.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptor.java
@@ -183,7 +183,7 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 		Preconditions.notNull(suggestedOrder, "orderer may not return null");
 
 		Set<? extends TestDescriptor> orderedChildren = new LinkedHashSet<>(suggestedOrder);
-		boolean unmodified = this.children.equals(orderedChildren);
+		var unmodified = this.children.equals(orderedChildren);
 		Preconditions.condition(unmodified && this.children.size() == suggestedOrder.size(),
 			"orderer may not add or remove test descriptors");
 
@@ -231,7 +231,7 @@ public abstract class AbstractTestDescriptor implements TestDescriptor {
 
 	private static String replaceControlCharacters(String text) {
 		StringBuilder builder = new StringBuilder();
-		for (int i = 0; i < text.length(); i++) {
+		for (var i = 0; i < text.length(); i++) {
 			builder.append(replaceControlCharacter(text.charAt(i)));
 		}
 		return builder.toString();

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClassSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClassSource.java
@@ -123,7 +123,7 @@ public final class ClassSource implements TestSource {
 
 		String className = uri.getSchemeSpecificPart();
 		FilePosition filePosition = null;
-		int indexOfQuery = className.indexOf('?');
+		var indexOfQuery = className.indexOf('?');
 		if (indexOfQuery >= 0) {
 			filePosition = FilePosition.fromQuery(className.substring(indexOfQuery + 1)).orElse(null);
 			className = className.substring(0, indexOfQuery);

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClasspathResourceSource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/descriptor/ClasspathResourceSource.java
@@ -122,7 +122,7 @@ public final class ClasspathResourceSource implements TestSource {
 
 	private ClasspathResourceSource(String classpathResourceName, @Nullable FilePosition filePosition) {
 		Preconditions.notBlank(classpathResourceName, "Classpath resource name must not be null or blank");
-		boolean startsWithSlash = classpathResourceName.startsWith("/");
+		var startsWithSlash = classpathResourceName.startsWith("/");
 		this.classpathResourceName = (startsWithSlash ? classpathResourceName.substring(1) : classpathResourceName);
 		this.filePosition = filePosition;
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/DiscoveryIssueReporter.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/DiscoveryIssueReporter.java
@@ -14,7 +14,6 @@ import static org.apiguardian.api.API.Status.EXPERIMENTAL;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -83,9 +82,9 @@ public interface DiscoveryIssueReporter {
 	 */
 	static DiscoveryIssueReporter deduplicating(DiscoveryIssueReporter delegate) {
 		Preconditions.notNull(delegate, "delegate must not be null");
-		Set<DiscoveryIssue> seen = new HashSet<>();
+		var seen = new HashSet<DiscoveryIssue>();
 		return issue -> {
-			boolean notSeen = seen.add(issue);
+			var notSeen = seen.add(issue);
 			if (notSeen) {
 				delegate.reportIssue(issue);
 			}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/ResourceUtils.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/discovery/ResourceUtils.java
@@ -37,7 +37,7 @@ class ResourceUtils {
 	}
 
 	private static String packageName(String classpathResourceName) {
-		int lastIndexOf = classpathResourceName.lastIndexOf(CLASSPATH_RESOURCE_PATH_SEPARATOR);
+		var lastIndexOf = classpathResourceName.lastIndexOf(CLASSPATH_RESOURCE_PATH_SEPARATOR);
 		if (lastIndexOf < 0) {
 			return DEFAULT_PACKAGE_NAME;
 		}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/CompositeLock.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/CompositeLock.java
@@ -47,7 +47,7 @@ class CompositeLock implements ResourceLock {
 
 	@Override
 	public boolean tryAcquire() {
-		List<Lock> acquiredLocks = new ArrayList<>(this.locks.size());
+		var acquiredLocks = new ArrayList<Lock>(this.locks.size());
 		for (Lock lock : this.locks) {
 			if (lock.tryLock()) {
 				acquiredLocks.add(lock);
@@ -72,7 +72,7 @@ class CompositeLock implements ResourceLock {
 	}
 
 	private void acquireAllLocks() throws InterruptedException {
-		List<Lock> acquiredLocks = new ArrayList<>(this.locks.size());
+		var acquiredLocks = new ArrayList<Lock>(this.locks.size());
 		try {
 			for (Lock lock : this.locks) {
 				lock.lockInterruptibly();
@@ -91,7 +91,7 @@ class CompositeLock implements ResourceLock {
 	}
 
 	private void release(List<Lock> acquiredLocks) {
-		for (int i = acquiredLocks.size() - 1; i >= 0; i--) {
+		for (var i = acquiredLocks.size() - 1; i >= 0; i--) {
 			acquiredLocks.get(i).unlock();
 		}
 	}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/DefaultParallelExecutionConfigurationStrategy.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/DefaultParallelExecutionConfigurationStrategy.java
@@ -39,16 +39,16 @@ public enum DefaultParallelExecutionConfigurationStrategy implements ParallelExe
 	FIXED {
 		@Override
 		public ParallelExecutionConfiguration createConfiguration(ConfigurationParameters configurationParameters) {
-			int parallelism = configurationParameters.get(CONFIG_FIXED_PARALLELISM_PROPERTY_NAME,
+			var parallelism = configurationParameters.get(CONFIG_FIXED_PARALLELISM_PROPERTY_NAME,
 				Integer::valueOf).orElseThrow(
 					() -> new JUnitException(
 						"Configuration parameter '%s' must be set".formatted(CONFIG_FIXED_PARALLELISM_PROPERTY_NAME)));
 
-			int maxPoolSize = configurationParameters.get(CONFIG_FIXED_MAX_POOL_SIZE_PROPERTY_NAME,
+			var maxPoolSize = configurationParameters.get(CONFIG_FIXED_MAX_POOL_SIZE_PROPERTY_NAME,
 				Integer::valueOf).orElse(parallelism + 256);
 
-			boolean saturate = configurationParameters.get(CONFIG_FIXED_SATURATE_PROPERTY_NAME,
-				Boolean::valueOf).orElse(true);
+			var saturate = configurationParameters.get(CONFIG_FIXED_SATURATE_PROPERTY_NAME, Boolean::valueOf).orElse(
+				true);
 
 			return new DefaultParallelExecutionConfiguration(parallelism, parallelism, maxPoolSize, parallelism,
 				KEEP_ALIVE_SECONDS, __ -> saturate);
@@ -70,10 +70,10 @@ public enum DefaultParallelExecutionConfigurationStrategy implements ParallelExe
 				() -> "Factor '%s' specified via configuration parameter '%s' must be greater than 0".formatted(factor,
 					CONFIG_DYNAMIC_FACTOR_PROPERTY_NAME));
 
-			int parallelism = Math.max(1,
+			var parallelism = Math.max(1,
 				factor.multiply(BigDecimal.valueOf(Runtime.getRuntime().availableProcessors())).intValue());
 
-			int maxPoolSize = configurationParameters.get(CONFIG_DYNAMIC_MAX_POOL_SIZE_FACTOR_PROPERTY_NAME,
+			var maxPoolSize = configurationParameters.get(CONFIG_DYNAMIC_MAX_POOL_SIZE_FACTOR_PROPERTY_NAME,
 				BigDecimal::new).map(maxPoolSizeFactor -> {
 					Preconditions.condition(maxPoolSizeFactor.compareTo(BigDecimal.ONE) >= 0,
 						() -> "Factor '%s' specified via configuration parameter '%s' must be greater than or equal to 1".formatted(
@@ -81,8 +81,8 @@ public enum DefaultParallelExecutionConfigurationStrategy implements ParallelExe
 					return maxPoolSizeFactor.multiply(BigDecimal.valueOf(parallelism)).intValue();
 				}).orElseGet(() -> 256 + parallelism);
 
-			boolean saturate = configurationParameters.get(CONFIG_DYNAMIC_SATURATE_PROPERTY_NAME,
-				Boolean::valueOf).orElse(true);
+			var saturate = configurationParameters.get(CONFIG_DYNAMIC_SATURATE_PROPERTY_NAME, Boolean::valueOf).orElse(
+				true);
 
 			return new DefaultParallelExecutionConfiguration(parallelism, parallelism, maxPoolSize, parallelism,
 				KEEP_ALIVE_SECONDS, __ -> saturate);

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ExclusiveResource.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ExclusiveResource.java
@@ -106,7 +106,7 @@ public class ExclusiveResource {
 
 	@Override
 	public int hashCode() {
-		int h = hash;
+		var h = hash;
 		if (h == 0) {
 			h = hash = Objects.hash(key, lockMode);
 		}

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorService.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/ForkJoinPoolHierarchicalTestExecutorService.java
@@ -146,9 +146,9 @@ public class ForkJoinPoolHierarchicalTestExecutorService implements Hierarchical
 			new ExclusiveTask(tasks.get(0)).execSync();
 			return;
 		}
-		Deque<ExclusiveTask> isolatedTasks = new ArrayDeque<>();
-		Deque<ExclusiveTask> sameThreadTasks = new ArrayDeque<>();
-		Deque<ExclusiveTask> concurrentTasksInReverseOrder = new ArrayDeque<>();
+		var isolatedTasks = new ArrayDeque<ExclusiveTask>();
+		var sameThreadTasks = new ArrayDeque<ExclusiveTask>();
+		var concurrentTasksInReverseOrder = new ArrayDeque<ExclusiveTask>();
 		forkConcurrentTasks(tasks, isolatedTasks, sameThreadTasks, concurrentTasksInReverseOrder);
 		executeSync(sameThreadTasks);
 		joinConcurrentTasksInReverseOrderToEnableWorkStealing(concurrentTasksInReverseOrder);
@@ -236,7 +236,7 @@ public class ForkJoinPoolHierarchicalTestExecutorService implements Hierarchical
 		}
 
 		void execSync() {
-			boolean completed = exec();
+			var completed = exec();
 			if (!completed) {
 				throw new IllegalStateException(
 					"Task was deferred but should have been executed synchronously: " + testTask);

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTreeWalker.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/NodeTreeWalker.java
@@ -74,7 +74,7 @@ class NodeTreeWalker {
 			Preconditions.notNull(globalLockDescriptor,
 				() -> "Node requiring exclusive resources must also require global read lock: " + testDescriptor);
 
-			Set<ExclusiveResource> allResources = new HashSet<>(exclusiveResources);
+			var allResources = new HashSet<ExclusiveResource>(exclusiveResources);
 			if (isReadOnly(allResources)) {
 				doForChildrenRecursively(testDescriptor, child -> allResources.addAll(getExclusiveResources(child)));
 				if (!isReadOnly(allResources)) {

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/WorkerThreadPoolHierarchicalTestExecutorService.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/hierarchical/WorkerThreadPoolHierarchicalTestExecutorService.java
@@ -195,7 +195,7 @@ public final class WorkerThreadPoolHierarchicalTestExecutorService implements Hi
 		}
 		workQueue.addAll(entries);
 		// start at most (parallelism - 1) new workers as this method is called from a worker thread holding a lease
-		for (int i = 0; i < Math.min(parallelism - 1, entries.size()); i++) {
+		for (var i = 0; i < Math.min(parallelism - 1, entries.size()); i++) {
 			maybeStartWorker();
 		}
 	}
@@ -351,8 +351,8 @@ public final class WorkerThreadPoolHierarchicalTestExecutorService implements Hi
 				return;
 			}
 
-			List<TestTask> isolatedTasks = new ArrayList<>(testTasks.size());
-			List<TestTask> sameThreadTasks = new ArrayList<>(testTasks.size());
+			var isolatedTasks = new ArrayList<TestTask>(testTasks.size());
+			var sameThreadTasks = new ArrayList<TestTask>(testTasks.size());
 			var queueEntries = forkConcurrentChildren(testTasks, isolatedTasks::add, sameThreadTasks);
 			executeAll(sameThreadTasks);
 			var queueEntriesByResult = tryToStealWorkWithoutBlocking(queueEntries);
@@ -364,7 +364,7 @@ public final class WorkerThreadPoolHierarchicalTestExecutorService implements Hi
 		private List<WorkQueue.Entry> forkConcurrentChildren(List<? extends TestTask> children,
 				Consumer<TestTask> isolatedTaskCollector, List<TestTask> sameThreadTasks) {
 
-			List<WorkQueue.Entry> queueEntries = new ArrayList<>(children.size());
+			var queueEntries = new ArrayList<WorkQueue.Entry>(children.size());
 			for (TestTask child : children) {
 				if (requiresGlobalReadWriteLock(child)) {
 					isolatedTaskCollector.accept(child);
@@ -392,7 +392,7 @@ public final class WorkerThreadPoolHierarchicalTestExecutorService implements Hi
 		private Map<WorkStealResult, List<WorkQueue.Entry>> tryToStealWorkWithoutBlocking(
 				Iterable<WorkQueue.Entry> queueEntries) {
 
-			Map<WorkStealResult, List<WorkQueue.Entry>> queueEntriesByResult = new EnumMap<>(WorkStealResult.class);
+			var queueEntriesByResult = new EnumMap<WorkStealResult, List<WorkQueue.Entry>>(WorkStealResult.class);
 			tryToStealWork(queueEntries, BlockingMode.NON_BLOCKING, queueEntriesByResult);
 			return queueEntriesByResult;
 		}
@@ -796,7 +796,7 @@ public final class WorkerThreadPoolHierarchicalTestExecutorService implements Hi
 					while (aIterator.hasNext()) {
 						var aCurrent = aIterator.next();
 						var bCurrent = bIterator.next();
-						int result = compareBy(aCurrent, bCurrent);
+						var result = compareBy(aCurrent, bCurrent);
 						if (result != 0) {
 							return result;
 						}
@@ -805,7 +805,7 @@ public final class WorkerThreadPoolHierarchicalTestExecutorService implements Hi
 				}
 
 				private static int compareBy(UniqueId.Segment a, UniqueId.Segment b) {
-					int result = a.getType().compareTo(b.getType());
+					var result = a.getType().compareTo(b.getType());
 					if (result != 0) {
 						return result;
 					}
@@ -830,7 +830,7 @@ public final class WorkerThreadPoolHierarchicalTestExecutorService implements Hi
 
 		@Nullable
 		WorkerLease tryAcquire() {
-			boolean acquired = semaphore.tryAcquire();
+			var acquired = semaphore.tryAcquire();
 			if (acquired) {
 				LOGGER.trace(() -> "acquired worker lease for new worker (available: %d)".formatted(
 					semaphore.availablePermits()));

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/store/Namespace.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/store/Namespace.java
@@ -96,7 +96,7 @@ public final class Namespace {
 	public Namespace append(Object... parts) {
 		Preconditions.notEmpty(parts, "parts array must not be null or empty");
 		Preconditions.containsNoNullElements(parts, "individual parts must not be null");
-		ArrayList<Object> newParts = new ArrayList<>(this.parts.size() + parts.length);
+		var newParts = new ArrayList<Object>(this.parts.size() + parts.length);
 		newParts.addAll(this.parts);
 		Collections.addAll(newParts, parts);
 		return new Namespace(newParts);

--- a/junit-platform-engine/src/main/java/org/junit/platform/engine/support/store/NamespacedHierarchicalStore.java
+++ b/junit-platform-engine/src/main/java/org/junit/platform/engine/support/store/NamespacedHierarchicalStore.java
@@ -21,7 +21,6 @@ import static org.junit.platform.commons.util.ReflectionUtils.isAssignableTo;
 
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -132,7 +131,7 @@ public final class NamespacedHierarchicalStore<N> implements AutoCloseable {
 		if (!this.closed) {
 			try {
 				if (this.closeAction != null) {
-					List<Throwable> failures = new ArrayList<>();
+					var failures = new ArrayList<Throwable>();
 					this.storedValues.entrySet().stream() //
 							.map(e -> e.getValue().evaluateSafely(e.getKey())) //
 							.filter(it -> it != null && it.value != null) //
@@ -210,7 +209,7 @@ public final class NamespacedHierarchicalStore<N> implements AutoCloseable {
 	public <K, V extends @Nullable Object> @Nullable Object getOrComputeIfAbsent(N namespace, K key,
 			Function<? super K, ? extends V> defaultCreator) {
 		Preconditions.notNull(defaultCreator, "defaultCreator must not be null");
-		CompositeKey<N> compositeKey = new CompositeKey<>(namespace, key);
+		var compositeKey = new CompositeKey<N>(namespace, key);
 		StoredValue storedValue = getStoredValue(compositeKey);
 		if (storedValue == null) {
 			storedValue = this.storedValues.computeIfAbsent(compositeKey,
@@ -240,7 +239,7 @@ public final class NamespacedHierarchicalStore<N> implements AutoCloseable {
 	@API(status = MAINTAINED, since = "6.0")
 	public <K, V> Object computeIfAbsent(N namespace, K key, Function<? super K, ? extends V> defaultCreator) {
 		Preconditions.notNull(defaultCreator, "defaultCreator must not be null");
-		CompositeKey<N> compositeKey = new CompositeKey<>(namespace, key);
+		var compositeKey = new CompositeKey<N>(namespace, key);
 		StoredValue storedValue = getStoredValue(compositeKey);
 		var result = StoredValue.evaluateIfNotNull(storedValue);
 		if (result == null) {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TagFilter.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TagFilter.java
@@ -133,7 +133,7 @@ public final class TagFilter {
 		List<TagExpression> parsedTagExpressions = parseAll(tagExpressions);
 		return descriptor -> {
 			Set<TestTag> tags = descriptor.getTags();
-			boolean included = parsedTagExpressions.stream().anyMatch(expression -> expression.evaluate(tags));
+			var included = parsedTagExpressions.stream().anyMatch(expression -> expression.evaluate(tags));
 
 			return FilterResult.includedIf(included, inclusionReason, exclusionReason);
 		};
@@ -153,7 +153,7 @@ public final class TagFilter {
 		List<TagExpression> parsedTagExpressions = parseAll(tagExpressions);
 		return descriptor -> {
 			Set<TestTag> tags = descriptor.getTags();
-			boolean included = parsedTagExpressions.stream().noneMatch(expression -> expression.evaluate(tags));
+			var included = parsedTagExpressions.stream().noneMatch(expression -> expression.evaluate(tags));
 
 			return FilterResult.includedIf(included, inclusionReason, exclusionReason);
 		};

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestPlan.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/TestPlan.java
@@ -227,7 +227,7 @@ public class TestPlan {
 	 */
 	public Set<TestIdentifier> getDescendants(TestIdentifier parent) {
 		Preconditions.notNull(parent, "parent must not be null");
-		Set<TestIdentifier> result = new LinkedHashSet<>(16);
+		var result = new LinkedHashSet<TestIdentifier>(16);
 		Set<TestIdentifier> children = getChildren(parent);
 		result.addAll(children);
 		for (TestIdentifier child : children) {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ClasspathAlignmentChecker.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ClasspathAlignmentChecker.java
@@ -15,7 +15,6 @@ import static java.util.Comparator.comparing;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
@@ -53,7 +52,7 @@ class ClasspathAlignmentChecker {
 
 	// VisibleForTesting
 	static Optional<JUnitException> check(LinkageError error, Function<String, @Nullable Package> packageLookup) {
-		Map<String, List<Package>> packagesByVersions = new HashMap<>();
+		var packagesByVersions = new HashMap<String, List<Package>>();
 		WELL_KNOWN_PACKAGES.stream() //
 				.map(packageLookup) //
 				.filter(Objects::nonNull) //

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DiscoveryIssueNotifier.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/DiscoveryIssueNotifier.java
@@ -119,7 +119,7 @@ class DiscoveryIssueNotifier {
 			message.append(issues.size()).append(' ').append(adjective).append(" issues");
 		}
 		message.append(" during test discovery:");
-		for (int i = 0; i < issues.size(); i++) {
+		for (var i = 0; i < issues.size(); i++) {
 			DiscoveryIssue issue = issues.get(i);
 			message.append("\n\n(").append(i + 1).append(") [").append(issue.severity()).append("] ").append(
 				issue.message());

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineDiscoveryOrchestrator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineDiscoveryOrchestrator.java
@@ -156,11 +156,11 @@ public class EngineDiscoveryOrchestrator {
 	private Map<TestEngine, EngineResultInfo> discoverSafely(LauncherDiscoveryRequest request,
 			Optional<LauncherPhase> phase, DiscoveryIssueCollector issueCollector,
 			Function<String, UniqueId> uniqueIdCreator) {
-		Map<TestEngine, EngineResultInfo> testEngineDescriptors = new LinkedHashMap<>();
+		var testEngineDescriptors = new LinkedHashMap<TestEngine, EngineResultInfo>();
 		EngineFilterer engineFilterer = new EngineFilterer(request.getEngineFilters());
 
 		for (TestEngine testEngine : this.testEngines) {
-			boolean engineIsExcluded = engineFilterer.isExcluded(testEngine);
+			var engineIsExcluded = engineFilterer.isExcluded(testEngine);
 
 			if (engineIsExcluded) {
 				logger.debug(() -> "Test discovery for engine '%s' was skipped due to an EngineFilter%s.".formatted(
@@ -177,7 +177,7 @@ public class EngineDiscoveryOrchestrator {
 
 		engineFilterer.performSanityChecks();
 
-		List<PostDiscoveryFilter> filters = new ArrayList<>(postDiscoveryFilters);
+		var filters = new ArrayList<PostDiscoveryFilter>(postDiscoveryFilters);
 		filters.addAll(request.getPostDiscoveryFilters());
 
 		applyPostDiscoveryFilters(testEngineDescriptors, filters);
@@ -224,7 +224,7 @@ public class EngineDiscoveryOrchestrator {
 	private void applyPostDiscoveryFilters(Map<TestEngine, EngineResultInfo> testEngineDescriptors,
 			List<PostDiscoveryFilter> filters) {
 		Filter<TestDescriptor> postDiscoveryFilter = composeFilters(filters);
-		Map<String, List<TestDescriptor>> excludedTestDescriptorsByReason = new LinkedHashMap<>();
+		var excludedTestDescriptorsByReason = new LinkedHashMap<String, List<TestDescriptor>>();
 		TestDescriptor.Visitor removeExcludedTestDescriptors = descriptor -> {
 			FilterResult filterResult = postDiscoveryFilter.apply(descriptor);
 			if (!descriptor.isRoot() && isExcluded(descriptor, filterResult)) {
@@ -245,8 +245,8 @@ public class EngineDiscoveryOrchestrator {
 	private void logTestDescriptorExclusionReasons(Map<String, List<TestDescriptor>> excludedTestDescriptorsByReason) {
 		excludedTestDescriptorsByReason.forEach((exclusionReason, testDescriptors) -> {
 			String displayNames = testDescriptors.stream().map(TestDescriptor::getDisplayName).collect(joining(", "));
-			long containerCount = testDescriptors.stream().filter(TestDescriptor::isContainer).count();
-			long methodCount = testDescriptors.stream().filter(TestDescriptor::isTest).count();
+			var containerCount = testDescriptors.stream().filter(TestDescriptor::isContainer).count();
+			var methodCount = testDescriptors.stream().filter(TestDescriptor::isTest).count();
 			logger.config(
 				() -> "%d containers and %d tests were %s".formatted(containerCount, methodCount, exclusionReason));
 			logger.debug(

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineDiscoveryResultValidator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineDiscoveryResultValidator.java
@@ -18,7 +18,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Queue;
 
 import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.engine.TestDescriptor;
@@ -52,10 +51,10 @@ class EngineDiscoveryResultValidator {
 	 */
 	private Optional<String> getCyclicGraphInfo(TestDescriptor root) {
 
-		Map<UniqueId, Optional<UniqueId>> visited = new HashMap<>();
+		var visited = new HashMap<UniqueId, Optional<UniqueId>>();
 		visited.put(root.getUniqueId(), Optional.empty());
 
-		Queue<TestDescriptor> queue = new ArrayDeque<>();
+		var queue = new ArrayDeque<TestDescriptor>();
 		queue.add(root);
 
 		while (!queue.isEmpty()) {
@@ -87,7 +86,7 @@ class EngineDiscoveryResultValidator {
 	}
 
 	private static List<UniqueId> findPath(Map<UniqueId, Optional<UniqueId>> visited, UniqueId target) {
-		List<UniqueId> path = new ArrayList<>();
+		var path = new ArrayList<UniqueId>();
 		path.add(target);
 		UniqueId current = target;
 

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineExecutionOrchestrator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineExecutionOrchestrator.java
@@ -182,7 +182,7 @@ public class EngineExecutionOrchestrator {
 
 	private static EngineExecutionListener selectExecutionListener(EngineExecutionListener engineExecutionListener,
 			ConfigurationParameters configurationParameters) {
-		boolean stackTracePruningEnabled = configurationParameters.getBoolean(STACKTRACE_PRUNING_ENABLED_PROPERTY_NAME) //
+		var stackTracePruningEnabled = configurationParameters.getBoolean(STACKTRACE_PRUNING_ENABLED_PROPERTY_NAME) //
 				.orElse(true);
 		if (stackTracePruningEnabled) {
 			return new StackTracePruningEngineExecutionListener(engineExecutionListener);

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineFilterer.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineFilterer.java
@@ -43,7 +43,7 @@ class EngineFilterer {
 	}
 
 	boolean isExcluded(TestEngine testEngine) {
-		boolean excluded = engineFilters.stream() //
+		var excluded = engineFilters.stream() //
 				.map(engineFilter -> engineFilter.apply(testEngine)) //
 				.anyMatch(FilterResult::excluded);
 		checkedTestEngines.put(testEngine, excluded);

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineIdValidator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/EngineIdValidator.java
@@ -11,7 +11,6 @@
 package org.junit.platform.launcher.core;
 
 import java.util.HashSet;
-import java.util.Set;
 
 import org.junit.platform.commons.JUnitException;
 import org.junit.platform.commons.logging.Logger;
@@ -28,7 +27,7 @@ class EngineIdValidator {
 	}
 
 	static Iterable<TestEngine> validate(Iterable<TestEngine> testEngines) {
-		Set<String> ids = new HashSet<>();
+		var ids = new HashSet<String>();
 		for (TestEngine testEngine : testEngines) {
 			// check usage of reserved ID prefix
 			if (!validateReservedIds(testEngine)) {

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherConfigurationParameters.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherConfigurationParameters.java
@@ -133,7 +133,7 @@ class LauncherConfigurationParameters implements ConfigurationParameters {
 		}
 
 		LauncherConfigurationParameters build() {
-			List<ParameterProvider> parameterProviders = new ArrayList<>();
+			var parameterProviders = new ArrayList<ParameterProvider>();
 			if (!explicitParameters.isEmpty()) {
 				parameterProviders.add(ParameterProvider.explicit(explicitParameters));
 			}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilder.java
@@ -427,7 +427,7 @@ public final class LauncherDiscoveryRequestBuilder {
 		if (this.discoveryListeners.contains(defaultDiscoveryListener)) {
 			return LauncherDiscoveryListeners.composite(this.discoveryListeners);
 		}
-		List<LauncherDiscoveryListener> allDiscoveryListeners = new ArrayList<>(this.discoveryListeners.size() + 1);
+		var allDiscoveryListeners = new ArrayList<LauncherDiscoveryListener>(this.discoveryListeners.size() + 1);
 		allDiscoveryListeners.addAll(this.discoveryListeners);
 		allDiscoveryListeners.add(defaultDiscoveryListener);
 		return LauncherDiscoveryListeners.composite(allDiscoveryListeners);

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherFactory.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/LauncherFactory.java
@@ -149,7 +149,7 @@ public class LauncherFactory {
 
 	private static List<LauncherInterceptor> collectLauncherInterceptors(
 			LauncherConfigurationParameters configurationParameters) {
-		List<LauncherInterceptor> interceptors = new ArrayList<>();
+		var interceptors = new ArrayList<LauncherInterceptor>();
 		if (configurationParameters.getBoolean(ENABLE_LAUNCHER_INTERCEPTORS).orElse(false)) {
 			ServiceLoaderRegistry.load(LauncherInterceptor.class).forEach(interceptors::add);
 		}
@@ -158,7 +158,7 @@ public class LauncherFactory {
 	}
 
 	private static Set<TestEngine> collectTestEngines(LauncherConfig config) {
-		Set<TestEngine> engines = new LinkedHashSet<>();
+		var engines = new LinkedHashSet<TestEngine>();
 		if (config.isTestEngineAutoRegistrationEnabled()) {
 			new ServiceLoaderTestEngineRegistry().loadTestEngines().forEach(engines::add);
 		}
@@ -176,7 +176,7 @@ public class LauncherFactory {
 	}
 
 	private static List<PostDiscoveryFilter> collectPostDiscoveryFilters(LauncherConfig config) {
-		List<PostDiscoveryFilter> filters = new ArrayList<>();
+		var filters = new ArrayList<PostDiscoveryFilter>();
 		if (config.isPostDiscoveryFilterAutoRegistrationEnabled()) {
 			ServiceLoaderRegistry.load(PostDiscoveryFilter.class).forEach(filters::add);
 		}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ListenerRegistry.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ListenerRegistry.java
@@ -50,7 +50,7 @@ class ListenerRegistry<T> {
 	}
 
 	static <T> ListenerRegistry<T> copyOf(ListenerRegistry<T> source) {
-		ListenerRegistry<T> registry = new ListenerRegistry<>(source.compositeListenerFactory);
+		var registry = new ListenerRegistry<T>(source.compositeListenerFactory);
 		if (!source.listeners.isEmpty()) {
 			registry.addAll(source.listeners);
 		}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ServiceLoaderRegistry.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/ServiceLoaderRegistry.java
@@ -33,9 +33,9 @@ class ServiceLoaderRegistry {
 
 	static <T> Iterable<T> load(@SuppressWarnings("SameParameterValue") Class<T> type,
 			Predicate<String> classNameFilter) {
-		List<String> exclusions = new ArrayList<>();
+		var exclusions = new ArrayList<String>();
 		Predicate<String> collectingClassNameFilter = className -> {
-			boolean included = classNameFilter.test(className);
+			var included = classNameFilter.test(className);
 			if (!included) {
 				exclusions.add(className);
 			}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StreamInterceptingTestExecutionListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StreamInterceptingTestExecutionListener.java
@@ -18,7 +18,6 @@ import static org.junit.platform.launcher.LauncherConstants.STDERR_REPORT_ENTRY_
 import static org.junit.platform.launcher.LauncherConstants.STDOUT_REPORT_ENTRY_KEY;
 
 import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 
@@ -41,13 +40,13 @@ class StreamInterceptingTestExecutionListener implements EagerTestExecutionListe
 	static Optional<StreamInterceptingTestExecutionListener> create(ConfigurationParameters configurationParameters,
 			BiConsumer<TestIdentifier, ReportEntry> reporter) {
 
-		boolean captureStdout = configurationParameters.getBoolean(CAPTURE_STDOUT_PROPERTY_NAME).orElse(false);
-		boolean captureStderr = configurationParameters.getBoolean(CAPTURE_STDERR_PROPERTY_NAME).orElse(false);
+		var captureStdout = configurationParameters.getBoolean(CAPTURE_STDOUT_PROPERTY_NAME).orElse(false);
+		var captureStderr = configurationParameters.getBoolean(CAPTURE_STDERR_PROPERTY_NAME).orElse(false);
 		if (!captureStdout && !captureStderr) {
 			return Optional.empty();
 		}
 
-		int maxSize = configurationParameters.get(CAPTURE_MAX_BUFFER_PROPERTY_NAME, Integer::valueOf) //
+		var maxSize = configurationParameters.get(CAPTURE_MAX_BUFFER_PROPERTY_NAME, Integer::valueOf) //
 				.orElse(CAPTURE_MAX_BUFFER_DEFAULT);
 
 		Optional<StreamInterceptor> stdoutInterceptor = captureStdout ? StreamInterceptor.registerStdout(maxSize)
@@ -83,7 +82,7 @@ class StreamInterceptingTestExecutionListener implements EagerTestExecutionListe
 
 	@Override
 	public void executionJustFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
-		Map<String, String> map = new HashMap<>();
+		var map = new HashMap<String, String>();
 		String out = stdoutInterceptor.map(StreamInterceptor::consume).orElse("");
 		if (StringUtils.isNotBlank(out)) {
 			map.put(STDOUT_REPORT_ENTRY_KEY, out);

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StreamInterceptor.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/StreamInterceptor.java
@@ -99,7 +99,7 @@ class StreamInterceptor extends PrintStream {
 	public void write(byte[] buf, int off, int len) {
 		RewindableByteArrayOutputStream out = getOutput();
 		if (out != null) {
-			int actualLength = Math.max(0, Math.min(len, maxNumberOfBytesPerThread - out.size()));
+			var actualLength = Math.max(0, Math.min(len, maxNumberOfBytesPerThread - out.size()));
 			if (actualLength > 0) {
 				pushToTop(out);
 				out.write(buf, off, actualLength);
@@ -137,7 +137,7 @@ class StreamInterceptor extends PrintStream {
 			if (position == null || position == count) {
 				return "";
 			}
-			int length = count - position;
+			var length = count - position;
 			count -= length;
 			return new String(buf, position, length, Charset.defaultCharset());
 		}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/TestEngineFormatter.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/core/TestEngineFormatter.java
@@ -39,7 +39,7 @@ class TestEngineFormatter {
 	}
 
 	private static List<String> computeAttributes(TestEngine engine) {
-		List<String> attributes = new ArrayList<>(4);
+		var attributes = new ArrayList<String>(4);
 		engine.getGroupId().ifPresent(groupId -> attributes.add("group ID: " + groupId));
 		engine.getArtifactId().ifPresent(artifactId -> attributes.add("artifact ID: " + artifactId));
 		engine.getVersion().ifPresent(version -> attributes.add("version: " + version));

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/MutableTestExecutionSummary.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/MutableTestExecutionSummary.java
@@ -219,7 +219,7 @@ class MutableTestExecutionSummary implements TestExecutionSummary {
 	}
 
 	private String describeTest(TestIdentifier testIdentifier) {
-		List<String> descriptionParts = new ArrayList<>();
+		var descriptionParts = new ArrayList<String>();
 		collectTestDescription(testIdentifier, descriptionParts);
 		return join(":", descriptionParts);
 	}
@@ -254,10 +254,10 @@ class MutableTestExecutionSummary implements TestExecutionSummary {
 		if (parentTrace.length > 0) {
 			writer.printf("%s%s%s%n", indentation, caption, throwable);
 		}
-		int duplicates = numberOfCommonFrames(trace, parentTrace);
-		int numDistinctFrames = trace.length - duplicates;
-		int numDisplayLines = Math.min(numDistinctFrames, max);
-		for (int i = 0; i < numDisplayLines; i++) {
+		var duplicates = numberOfCommonFrames(trace, parentTrace);
+		var numDistinctFrames = trace.length - duplicates;
+		var numDisplayLines = Math.min(numDistinctFrames, max);
+		for (var i = 0; i < numDisplayLines; i++) {
 			writer.printf("%s%s%s%n", indentation, TAB, trace[i]);
 		}
 		if (trace.length > max || duplicates != 0) {
@@ -273,8 +273,8 @@ class MutableTestExecutionSummary implements TestExecutionSummary {
 	}
 
 	private int numberOfCommonFrames(StackTraceElement[] currentTrace, StackTraceElement[] parentTrace) {
-		int currentIndex = currentTrace.length - 1;
-		for (int parentIndex = parentTrace.length - 1; currentIndex >= 0
+		var currentIndex = currentTrace.length - 1;
+		for (var parentIndex = parentTrace.length - 1; currentIndex >= 0
 				&& parentIndex >= 0; currentIndex--, parentIndex--) {
 			if (!currentTrace[currentIndex].equals(parentTrace[parentIndex])) {
 				break;

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/SummaryGeneratingListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/SummaryGeneratingListener.java
@@ -82,10 +82,10 @@ public class SummaryGeneratingListener implements TestExecutionListener {
 	public void executionSkipped(TestIdentifier testIdentifier, String reason) {
 		var testPlan = requireNonNull(this.testPlan);
 		// @formatter:off
-		long skippedContainers = concat(Stream.of(testIdentifier), testPlan.getDescendants(testIdentifier).stream())
+		var skippedContainers = concat(Stream.of(testIdentifier), testPlan.getDescendants(testIdentifier).stream())
 				.filter(TestIdentifier::isContainer)
 				.count();
-		long skippedTests = concat(Stream.of(testIdentifier), testPlan.getDescendants(testIdentifier).stream())
+		var skippedTests = concat(Stream.of(testIdentifier), testPlan.getDescendants(testIdentifier).stream())
 				.filter(TestIdentifier::isTest)
 				.count();
 		// @formatter:on

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/UniqueIdTrackingListener.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/listeners/UniqueIdTrackingListener.java
@@ -166,7 +166,7 @@ public class UniqueIdTrackingListener implements TestExecutionListener {
 	}
 
 	private void trackTestUidRecursively(TestIdentifier testIdentifier) {
-		boolean tracked = trackTestUid(testIdentifier);
+		var tracked = trackTestUid(testIdentifier);
 		if (!tracked) {
 			requireNonNull(this.testPlan).getChildren(testIdentifier).forEach(this::trackTestUidRecursively);
 		}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/tagexpression/Operator.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/tagexpression/Operator.java
@@ -129,7 +129,7 @@ class Operator {
 		}
 
 		if (2 == arity) {
-			int mismatch = arity - expressions.size();
+			var mismatch = arity - expressions.size();
 			if (2 == mismatch) {
 				return "missing lhs and rhs operand";
 			}

--- a/junit-platform-launcher/src/main/java/org/junit/platform/launcher/tagexpression/Tokenizer.java
+++ b/junit-platform-launcher/src/main/java/org/junit/platform/launcher/tagexpression/Tokenizer.java
@@ -31,7 +31,7 @@ class Tokenizer {
 		if (infixTagExpression == null) {
 			return List.of();
 		}
-		List<Token> parts = new ArrayList<>();
+		var parts = new ArrayList<Token>();
 		Matcher matcher = PATTERN.matcher(infixTagExpression);
 		while (matcher.find()) {
 			parts.add(new Token(matcher.start(), matcher.group()));

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/XmlReportData.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/XmlReportData.java
@@ -133,7 +133,7 @@ class XmlReportData {
 
 	private List<TestIdentifier> getAncestors(TestIdentifier testIdentifier) {
 		TestIdentifier current = testIdentifier;
-		List<TestIdentifier> ancestors = new ArrayList<>();
+		var ancestors = new ArrayList<TestIdentifier>();
 		while (current != null) {
 			ancestors.add(current);
 			current = this.testPlan.getParent(current).orElse(null);

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/XmlReportWriter.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/legacy/xml/XmlReportWriter.java
@@ -172,7 +172,7 @@ class XmlReportWriter {
 		private void writeTestCounts(Collection<AggregatedTestResult> testResults) throws XMLStreamException {
 			Map<Type, Long> counts = testResults.stream().map(it -> it.type).collect(
 				groupingBy(identity(), counting()));
-			long total = counts.values().stream().mapToLong(Long::longValue).sum();
+			var total = counts.values().stream().mapToLong(Long::longValue).sum();
 			writeAttributeSafely("tests", String.valueOf(total));
 			writeAttributeSafely("skipped", counts.getOrDefault(SKIPPED, 0L).toString());
 			writeAttributeSafely("failures", counts.getOrDefault(FAILURE, 0L).toString());
@@ -205,8 +205,8 @@ class XmlReportWriter {
 
 			writeSkippedOrErrorOrFailureElement(testIdentifier, testResult);
 
-			List<String> systemOutElements = new ArrayList<>();
-			List<String> systemErrElements = new ArrayList<>();
+			var systemOutElements = new ArrayList<String>();
+			var systemErrElements = new ArrayList<String>();
 			systemOutElements.add(formatNonStandardAttributesAsString(testIdentifier));
 			collectReportEntries(testIdentifier, systemOutElements, systemErrElements);
 			writeOutputElements("system-out", systemOutElements);
@@ -280,11 +280,11 @@ class XmlReportWriter {
 				List<String> systemErrElements) {
 			List<ReportEntry> entries = reportData.getReportEntries(testIdentifier);
 			if (!entries.isEmpty()) {
-				List<String> systemOutElementsForCapturedOutput = new ArrayList<>();
+				var systemOutElementsForCapturedOutput = new ArrayList<String>();
 				StringBuilder formattedReportEntries = new StringBuilder();
-				for (int i = 0; i < entries.size(); i++) {
+				for (var i = 0; i < entries.size(); i++) {
 					ReportEntry reportEntry = entries.get(i);
-					Map<String, String> keyValuePairs = new LinkedHashMap<>(reportEntry.getKeyValuePairs());
+					var keyValuePairs = new LinkedHashMap<String, String>(reportEntry.getKeyValuePairs());
 					removeIfPresentAndAddAsSeparateElement(keyValuePairs, STDOUT_REPORT_ENTRY_KEY,
 						systemOutElementsForCapturedOutput);
 					removeIfPresentAndAddAsSeparateElement(keyValuePairs, STDERR_REPORT_ENTRY_KEY, systemErrElements);
@@ -468,8 +468,8 @@ class XmlReportWriter {
 				return;
 			}
 			StringBuilder stringBuilder = new StringBuilder(len * 2);
-			for (int i = off; i < off + len; i++) {
-				char c = cbuf[i];
+			for (var i = off; i < off + len; i++) {
+				var c = cbuf[i];
 				String replacement = REPLACEMENTS_IN_ATTRIBUTE_VALUES.get(c);
 				if (replacement != null) {
 					stringBuilder.append(replacement);

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/open/xml/GitInfoCollector.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/open/xml/GitInfoCollector.java
@@ -34,7 +34,7 @@ interface GitInfoCollector {
 
 	static Optional<GitInfoCollector> get(Path workingDir) {
 		ProcessExecutor executor = new ProcessExecutor(workingDir);
-		boolean gitInstalled = executor.exec("git", "--version").isPresent();
+		var gitInstalled = executor.exec("git", "--version").isPresent();
 		return gitInstalled ? Optional.of(new CliGitInfoCollector(executor)) : Optional.empty();
 	}
 
@@ -144,7 +144,7 @@ interface GitInfoCollector {
 					// ignore
 				});
 
-				boolean terminated = process.waitFor(10, TimeUnit.SECONDS);
+				var terminated = process.waitFor(10, TimeUnit.SECONDS);
 				return terminated && process.exitValue() == 0 ? Optional.of(trimAtEnd(output)) : Optional.empty();
 			}
 			catch (InterruptedException e) {
@@ -182,8 +182,8 @@ interface GitInfoCollector {
 		}
 
 		private static String trimAtEnd(StringBuilder value) {
-			int endIndex = value.length();
-			for (int i = value.length() - 1; i >= 0; i--) {
+			var endIndex = value.length();
+			for (var i = value.length() - 1; i >= 0; i--) {
 				if (Character.isWhitespace(value.charAt(i))) {
 					endIndex--;
 					break;

--- a/junit-platform-reporting/src/main/java/org/junit/platform/reporting/open/xml/JUnitContributor.java
+++ b/junit-platform-reporting/src/main/java/org/junit/platform/reporting/open/xml/JUnitContributor.java
@@ -15,7 +15,6 @@ import static org.apiguardian.api.API.Status.INTERNAL;
 
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import org.apiguardian.api.API;
@@ -43,7 +42,7 @@ public class JUnitContributor implements Contributor {
 	public List<Section> contributeSectionsForTestNode(Context context) {
 		return findChild(context.element(), Namespace.REPORTING_CORE, "metadata") //
 				.map(metadata -> {
-					Map<String, String> table = new LinkedHashMap<>();
+					var table = new LinkedHashMap<String, String>();
 					findChild(metadata, JUnitFactory.NAMESPACE, "type") //
 							.map(Node::getTextContent) //
 							.ifPresent(value -> table.put("Type", value));
@@ -66,7 +65,7 @@ public class JUnitContributor implements Contributor {
 
 	private static Optional<Node> findChild(Node parent, Namespace namespace, String localName) {
 		NodeList children = parent.getChildNodes();
-		for (int i = 0; i < children.getLength(); i++) {
+		for (var i = 0; i < children.getLength(); i++) {
 			Node child = children.item(i);
 			if (localName.equals(child.getLocalName()) && namespace.getUri().equals(child.getNamespaceURI())) {
 				return Optional.of(child);

--- a/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/ClassSelectorResolver.java
+++ b/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/ClassSelectorResolver.java
@@ -123,7 +123,7 @@ final class ClassSelectorResolver implements SelectorResolver {
 		List<Segment> segments = id.getSegments();
 		List<Segment> engineAndSuiteSegment = segments.subList(segments.size() - 2, segments.size());
 		List<Segment> ancestorSegments = segments.subList(0, segments.size() - 2);
-		for (int i = 0; i < ancestorSegments.size() - 1; i++) {
+		for (var i = 0; i < ancestorSegments.size() - 1; i++) {
 			List<Segment> candidate = ancestorSegments.subList(i, i + 2);
 			if (engineAndSuiteSegment.equals(candidate)) {
 				return true;

--- a/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteLauncher.java
+++ b/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteLauncher.java
@@ -39,7 +39,7 @@ class SuiteLauncher {
 	private final EngineDiscoveryOrchestrator discoveryOrchestrator;
 
 	static SuiteLauncher create() {
-		Set<TestEngine> engines = new LinkedHashSet<>();
+		var engines = new LinkedHashSet<TestEngine>();
 		new ServiceLoaderTestEngineRegistry().loadTestEngines().forEach(engines::add);
 		return new SuiteLauncher(engines);
 	}

--- a/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteTestDescriptor.java
+++ b/junit-platform-suite-engine/src/main/java/org/junit/platform/suite/engine/SuiteTestDescriptor.java
@@ -253,7 +253,7 @@ final class SuiteTestDescriptor extends AbstractTestDescriptor {
 		private static final Predicate<Segment> SUITE_SEGMENTS = where(Segment::getType, isEqual(SEGMENT_TYPE));
 
 		static DiscoveryIssueForwardingListener create(UniqueId id, EngineDiscoveryListener discoveryListener) {
-			boolean isNestedSuite = id.getSegments().stream().filter(SUITE_SEGMENTS).count() > 1;
+			var isNestedSuite = id.getSegments().stream().filter(SUITE_SEGMENTS).count() > 1;
 			if (isNestedSuite) {
 				return new DiscoveryIssueForwardingListener(discoveryListener, (__, issue) -> issue);
 			}

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EventConditions.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/EventConditions.java
@@ -219,7 +219,7 @@ public final class EventConditions {
 		Preconditions.notNull(clazz, "Class must not be null");
 		Preconditions.notNull(clazz.getEnclosingClass(), () -> clazz.getName() + " must be a nested class");
 
-		List<String> classNames = new ArrayList<>();
+		var classNames = new ArrayList<String>();
 		for (Class<?> current = clazz; current != null; current = current.getEnclosingClass()) {
 			classNames.add(0, current.getSimpleName());
 		}

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Events.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Events.java
@@ -419,7 +419,7 @@ public final class Events {
 		Assertions.assertThat(events).hasSize(conditions.length);
 
 		SoftAssertions softly = new SoftAssertions();
-		for (int i = 0; i < conditions.length; i++) {
+		for (var i = 0; i < conditions.length; i++) {
 			softly.assertThat(events).has(conditions[i], Index.atIndex(i));
 		}
 		softly.assertAll();
@@ -456,7 +456,7 @@ public final class Events {
 	}
 
 	private static boolean isNotInIncreasingOrder(List<Integer> indices) {
-		List<Integer> copy = new ArrayList<>(indices);
+		var copy = new ArrayList<Integer>(indices);
 		sort(copy);
 
 		return !indices.equals(copy);

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Executions.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/Executions.java
@@ -19,7 +19,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -251,8 +250,8 @@ public final class Executions {
 	 * Create executions from the supplied list of events.
 	 */
 	private static List<Execution> createExecutions(List<Event> events) {
-		List<Execution> executions = new ArrayList<>();
-		Map<TestDescriptor, Instant> executionStarts = new HashMap<>();
+		var executions = new ArrayList<Execution>();
+		var executionStarts = new HashMap<TestDescriptor, Instant>();
 
 		for (Event event : events) {
 			switch (event.getType()) {

--- a/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/TerminationInfo.java
+++ b/junit-platform-testkit/src/main/java/org/junit/platform/testkit/engine/TerminationInfo.java
@@ -66,7 +66,7 @@ public class TerminationInfo {
 
 	private TerminationInfo(boolean skipped, @Nullable String skipReason,
 			@Nullable TestExecutionResult testExecutionResult) {
-		boolean executed = (testExecutionResult != null);
+		var executed = (testExecutionResult != null);
 		Preconditions.condition((skipped ^ executed),
 			"TerminationInfo must represent either a skipped execution or a TestExecutionResult but not both");
 

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/DescriptionUtils.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/DescriptionUtils.java
@@ -22,11 +22,11 @@ public class DescriptionUtils {
 
 	public static @Nullable String getMethodName(Description description) {
 		String displayName = description.getDisplayName();
-		int i = displayName.indexOf('(');
+		var i = displayName.indexOf('(');
 		if (i >= 0) {
-			int j = displayName.lastIndexOf('(');
+			var j = displayName.lastIndexOf('(');
 			if (i == j) {
-				char lastChar = displayName.charAt(displayName.length() - 1);
+				var lastChar = displayName.charAt(displayName.length() - 1);
 				if (lastChar == ')') {
 					return displayName.substring(0, i);
 				}

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/RunnerTestDescriptor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/RunnerTestDescriptor.java
@@ -79,7 +79,7 @@ public class RunnerTestDescriptor extends VintageTestDescriptor {
 
 	@Override
 	protected boolean tryToExcludeFromRunner(Description description) {
-		boolean excluded = tryToFilterRunner(description);
+		var excluded = tryToFilterRunner(description);
 		if (excluded) {
 			wasFiltered = true;
 		}

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/VintageTestDescriptor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/descriptor/VintageTestDescriptor.java
@@ -83,7 +83,7 @@ public class VintageTestDescriptor extends AbstractTestDescriptor {
 
 	@Override
 	public Set<TestTag> getTags() {
-		Set<TestTag> tags = new LinkedHashSet<>();
+		var tags = new LinkedHashSet<TestTag>();
 		addTagsFromParent(tags);
 		addCategoriesAsTags(tags);
 		return tags;

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/RunnerTestDescriptorPostProcessor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/RunnerTestDescriptorPostProcessor.java
@@ -54,7 +54,7 @@ class RunnerTestDescriptorPostProcessor {
 			String uniqueId = entry.getKey();
 			List<Description> childrenWithSameUniqueId = entry.getValue();
 			IntFunction<String> uniqueIdGenerator = determineUniqueIdGenerator(uniqueId, childrenWithSameUniqueId);
-			for (int index = 0; index < childrenWithSameUniqueId.size(); index++) {
+			for (var index = 0; index < childrenWithSameUniqueId.size(); index++) {
 				String reallyUniqueId = uniqueIdGenerator.apply(index);
 				Description description = childrenWithSameUniqueId.get(index);
 				UniqueId id = parent.getUniqueId().append(VintageTestDescriptor.SEGMENT_TYPE_TEST, reallyUniqueId);

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/UniqueIdFilter.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/discovery/UniqueIdFilter.java
@@ -55,7 +55,7 @@ class UniqueIdFilter extends Filter {
 
 	private Deque<Description> determinePath(RunnerTestDescriptor runnerTestDescriptor,
 			Optional<? extends TestDescriptor> identifiedTestDescriptor) {
-		Deque<Description> path = new ArrayDeque<>();
+		var path = new ArrayDeque<Description>();
 		Optional<? extends TestDescriptor> current = identifiedTestDescriptor;
 		while (current.isPresent() && !current.get().equals(runnerTestDescriptor)) {
 			path.addFirst(((VintageTestDescriptor) current.get()).getDescription());

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/TestRun.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/TestRun.java
@@ -88,7 +88,7 @@ class TestRun {
 	}
 
 	Collection<TestDescriptor> getInProgressTestDescriptors() {
-		List<TestDescriptor> result = new ArrayList<>(inProgressDescriptors.keySet());
+		var result = new ArrayList<TestDescriptor>(inProgressDescriptors.keySet());
 		Collections.reverse(result);
 		return result;
 	}
@@ -218,8 +218,7 @@ class TestRun {
 		private int skippedOrStartedCount;
 
 		static VintageDescriptors merge(VintageDescriptors a, VintageDescriptors b) {
-			List<VintageTestDescriptor> mergedDescriptors = new ArrayList<>(
-				a.descriptors.size() + b.descriptors.size());
+			var mergedDescriptors = new ArrayList<VintageTestDescriptor>(a.descriptors.size() + b.descriptors.size());
 			mergedDescriptors.addAll(a.descriptors);
 			mergedDescriptors.addAll(b.descriptors);
 			return new VintageDescriptors(mergedDescriptors);

--- a/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/VintageExecutor.java
+++ b/junit-vintage-engine/src/main/java/org/junit/vintage/engine/execution/VintageExecutor.java
@@ -80,7 +80,7 @@ public class VintageExecutor {
 			return;
 		}
 
-		boolean wasInterrupted = executeInParallel(cancellationToken);
+		var wasInterrupted = executeInParallel(cancellationToken);
 		if (wasInterrupted) {
 			Thread.currentThread().interrupt();
 		}
@@ -112,7 +112,7 @@ public class VintageExecutor {
 		Optional<String> optionalPoolSize = configurationParameters.get(Constants.PARALLEL_POOL_SIZE);
 		if (optionalPoolSize.isPresent()) {
 			try {
-				int poolSize = Integer.parseInt(optionalPoolSize.get());
+				var poolSize = Integer.parseInt(optionalPoolSize.get());
 				if (poolSize > 0) {
 					return poolSize;
 				}
@@ -147,7 +147,7 @@ public class VintageExecutor {
 
 	private boolean executeClassesInParallel(List<RunnerTestDescriptor> runnerTestDescriptors,
 			RunnerExecutor runnerExecutor, ExecutorService executorService) {
-		List<CompletableFuture<Void>> futures = new ArrayList<>();
+		var futures = new ArrayList<CompletableFuture<Void>>();
 		for (RunnerTestDescriptor runnerTestDescriptor : runnerTestDescriptors) {
 			CompletableFuture<Void> future = CompletableFuture.runAsync(
 				() -> runnerExecutor.execute(runnerTestDescriptor), executorService);
@@ -155,7 +155,7 @@ public class VintageExecutor {
 		}
 
 		CompletableFuture<Void> allOf = CompletableFuture.allOf(futures.toArray(new CompletableFuture<?>[0]));
-		boolean wasInterrupted = false;
+		var wasInterrupted = false;
 		try {
 			allOf.get();
 		}

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/JUnit4ParameterizedTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/JUnit4ParameterizedTests.java
@@ -40,7 +40,7 @@ class JUnit4ParameterizedTests {
 	void selectingWholeParameterizedClassRunsTestsWithAllValues() {
 		executeTests(selectClass(JUnit4ParameterizedTestCase.class));
 
-		Map<TestExecutionResult.Status, Integer> expectedCallCounts = new HashMap<>();
+		var expectedCallCounts = new HashMap<TestExecutionResult.Status, Integer>();
 		expectedCallCounts.put(SUCCESSFUL, 3);
 		expectedCallCounts.put(FAILED, 9);
 

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageLauncherIntegrationTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageLauncherIntegrationTests.java
@@ -266,7 +266,7 @@ class VintageLauncherIntegrationTests {
 	}
 
 	private Map<TestIdentifier, TestExecutionResult> execute(LauncherDiscoveryRequestBuilder requestBuilder) {
-		Map<TestIdentifier, TestExecutionResult> results = new LinkedHashMap<>();
+		var results = new LinkedHashMap<TestIdentifier, TestExecutionResult>();
 		var launcher = LauncherFactory.create();
 		var listener = new TestExecutionListener() {
 			@Override

--- a/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineDiscoveryTests.java
+++ b/junit-vintage-engine/src/test/java/org/junit/vintage/engine/VintageTestEngineDiscoveryTests.java
@@ -209,7 +209,7 @@ class VintageTestEngineDiscoveryTests {
 		var runnerDescriptor = getOnlyElement(engineDescriptor.getChildren());
 		assertRunnerTestDescriptor(runnerDescriptor, testClass);
 
-		List<TestDescriptor> testMethodDescriptors = new ArrayList<>(runnerDescriptor.getChildren());
+		var testMethodDescriptors = new ArrayList<TestDescriptor>(runnerDescriptor.getChildren());
 		assertThat(testMethodDescriptors).hasSize(2);
 
 		var testMethodDescriptor = testMethodDescriptors.getFirst();
@@ -235,7 +235,7 @@ class VintageTestEngineDiscoveryTests {
 		var runnerDescriptor = getOnlyElement(engineDescriptor.getChildren());
 		assertRunnerTestDescriptor(runnerDescriptor, testClass);
 
-		List<TestDescriptor> testMethodDescriptors = new ArrayList<>(runnerDescriptor.getChildren());
+		var testMethodDescriptors = new ArrayList<TestDescriptor>(runnerDescriptor.getChildren());
 
 		var testMethodDescriptor = getOnlyElement(testMethodDescriptors);
 		assertEquals("test", testMethodDescriptor.getDisplayName());
@@ -442,7 +442,7 @@ class VintageTestEngineDiscoveryTests {
 		var runnerDescriptor = getOnlyElement(engineDescriptor.getChildren());
 		assertRunnerTestDescriptor(runnerDescriptor, testClass);
 
-		List<TestDescriptor> testMethodDescriptors = new ArrayList<>(runnerDescriptor.getChildren());
+		var testMethodDescriptors = new ArrayList<TestDescriptor>(runnerDescriptor.getChildren());
 		assertThat(testMethodDescriptors).hasSize(2);
 
 		var failingTest = testMethodDescriptors.get(0);
@@ -536,7 +536,7 @@ class VintageTestEngineDiscoveryTests {
 		var runnerDescriptor = getOnlyElement(engineDescriptor.getChildren());
 		assertRunnerTestDescriptor(runnerDescriptor, testClass);
 
-		List<TestDescriptor> testMethodDescriptors = new ArrayList<>(runnerDescriptor.getChildren());
+		var testMethodDescriptors = new ArrayList<TestDescriptor>(runnerDescriptor.getChildren());
 		assertThat(testMethodDescriptors).hasSize(2);
 		assertTestMethodDescriptor(testMethodDescriptors.get(0), testClass, "failingTest",
 			VintageUniqueIdBuilder.uniqueIdForClass(testClass));
@@ -588,7 +588,7 @@ class VintageTestEngineDiscoveryTests {
 		var runnerDescriptor = getOnlyElement(engineDescriptor.getChildren());
 		assertRunnerTestDescriptor(runnerDescriptor, testClass);
 
-		List<TestDescriptor> testMethodDescriptors = new ArrayList<>(runnerDescriptor.getChildren());
+		var testMethodDescriptors = new ArrayList<TestDescriptor>(runnerDescriptor.getChildren());
 		assertThat(testMethodDescriptors).hasSize(2);
 		assertTestMethodDescriptor(testMethodDescriptors.get(0), testClass, "abortedTest",
 			VintageUniqueIdBuilder.uniqueIdForClass(testClass));

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertDoesNotThrowAssertionsTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertDoesNotThrowAssertionsTests.java
@@ -36,7 +36,7 @@ class AssertDoesNotThrowAssertionsTests {
 
 	@Test
 	void assertDoesNotThrowWithMethodReferenceForNonVoidReturnType() {
-		FutureTask<String> future = new FutureTask<>(() -> "foo");
+		var future = new FutureTask<String>(() -> "foo");
 		future.run();
 
 		String result;

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertEqualsAssertionsTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertEqualsAssertionsTests.java
@@ -654,7 +654,7 @@ class AssertEqualsAssertionsTests {
 
 		@Test
 		void integers() {
-			int primitive = 42;
+			var primitive = 42;
 			Integer wrapper = Integer.valueOf("42");
 
 			assertEquals(primitive, wrapper);
@@ -668,7 +668,7 @@ class AssertEqualsAssertionsTests {
 
 		@Test
 		void longs() {
-			long primitive = 42L;
+			var primitive = 42L;
 			Long wrapper = Long.valueOf("42");
 
 			assertEquals(primitive, wrapper);
@@ -682,7 +682,7 @@ class AssertEqualsAssertionsTests {
 
 		@Test
 		void floats() {
-			float primitive = 42.0f;
+			var primitive = 42.0f;
 			Float wrapper = Float.valueOf("42.0");
 
 			assertEquals(primitive, wrapper);
@@ -702,7 +702,7 @@ class AssertEqualsAssertionsTests {
 
 		@Test
 		void doubles() {
-			double primitive = 42.0d;
+			var primitive = 42.0d;
 			Double wrapper = Double.valueOf("42.0");
 
 			assertEquals(primitive, wrapper);
@@ -722,7 +722,7 @@ class AssertEqualsAssertionsTests {
 
 		@Test
 		void booleans() {
-			boolean primitive = true;
+			var primitive = true;
 			Boolean wrapper = Boolean.valueOf("true");
 
 			assertEquals(primitive, wrapper);
@@ -736,7 +736,7 @@ class AssertEqualsAssertionsTests {
 
 		@Test
 		void chars() {
-			char primitive = 'a';
+			var primitive = 'a';
 			Character wrapper = Character.valueOf('a');
 
 			assertEquals(primitive, wrapper);

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertNotEqualsAssertionsTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertNotEqualsAssertionsTests.java
@@ -141,8 +141,8 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void assertNotEqualsChar() {
-			char unexpected = 'a';
-			char actual = 'b';
+			var unexpected = 'a';
+			var actual = 'b';
 			assertNotEquals(unexpected, actual);
 			assertNotEquals(unexpected, actual, "message");
 			assertNotEquals(unexpected, actual, () -> "message");
@@ -150,8 +150,8 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void withEqualValues() {
-			char unexpected = 'a';
-			char actual = 'a';
+			var unexpected = 'a';
+			var actual = 'a';
 			try {
 				assertNotEquals(unexpected, actual);
 				expectAssertionFailedError();
@@ -163,8 +163,8 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void withEqualValuesWithMessage() {
-			char unexpected = 'a';
-			char actual = 'a';
+			var unexpected = 'a';
+			var actual = 'a';
 			try {
 				assertNotEquals(unexpected, actual, "custom message");
 				expectAssertionFailedError();
@@ -177,8 +177,8 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void withEqualValuesWithMessageSupplier() {
-			char unexpected = 'a';
-			char actual = 'a';
+			var unexpected = 'a';
+			var actual = 'a';
 			try {
 				assertNotEquals(unexpected, actual, () -> "custom message from supplier");
 				expectAssertionFailedError();
@@ -196,8 +196,8 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void assertNotEqualsInt() {
-			int unexpected = 1;
-			int actual = 2;
+			var unexpected = 1;
+			var actual = 2;
 			assertNotEquals(unexpected, actual);
 			assertNotEquals(unexpected, actual, "message");
 			assertNotEquals(unexpected, actual, () -> "message");
@@ -205,8 +205,8 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void withEqualValues() {
-			int unexpected = 1;
-			int actual = 1;
+			var unexpected = 1;
+			var actual = 1;
 			try {
 				assertNotEquals(unexpected, actual);
 				expectAssertionFailedError();
@@ -218,8 +218,8 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void withEqualValuesWithMessage() {
-			int unexpected = 1;
-			int actual = 1;
+			var unexpected = 1;
+			var actual = 1;
 			try {
 				assertNotEquals(unexpected, actual, "custom message");
 				expectAssertionFailedError();
@@ -232,8 +232,8 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void withEqualValuesWithMessageSupplier() {
-			int unexpected = 1;
-			int actual = 1;
+			var unexpected = 1;
+			var actual = 1;
 			try {
 				assertNotEquals(unexpected, actual, () -> "custom message from supplier");
 				expectAssertionFailedError();
@@ -251,8 +251,8 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void assertNotEqualsLong() {
-			long unexpected = 1L;
-			long actual = 2L;
+			var unexpected = 1L;
+			var actual = 2L;
 			assertNotEquals(unexpected, actual);
 			assertNotEquals(unexpected, actual, "message");
 			assertNotEquals(unexpected, actual, () -> "message");
@@ -260,8 +260,8 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void withEqualValues() {
-			long unexpected = 1L;
-			long actual = 1L;
+			var unexpected = 1L;
+			var actual = 1L;
 			try {
 				assertNotEquals(unexpected, actual);
 				expectAssertionFailedError();
@@ -273,8 +273,8 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void withEqualValuesWithMessage() {
-			long unexpected = 1L;
-			long actual = 1L;
+			var unexpected = 1L;
+			var actual = 1L;
 			try {
 				assertNotEquals(unexpected, actual, "custom message");
 				expectAssertionFailedError();
@@ -287,8 +287,8 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void withEqualValuesWithMessageSupplier() {
-			long unexpected = 1L;
-			long actual = 1L;
+			var unexpected = 1L;
+			var actual = 1L;
 			try {
 				assertNotEquals(unexpected, actual, () -> "custom message from supplier");
 				expectAssertionFailedError();
@@ -306,8 +306,8 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void assertNotEqualsFloat() {
-			float unexpected = 1.0f;
-			float actual = 2.0f;
+			var unexpected = 1.0f;
+			var actual = 2.0f;
 			assertNotEquals(unexpected, actual);
 			assertNotEquals(unexpected, actual, "message");
 			assertNotEquals(unexpected, actual, () -> "message");
@@ -348,8 +348,8 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void withEqualValues() {
-			float unexpected = 1.0f;
-			float actual = 1.0f;
+			var unexpected = 1.0f;
+			var actual = 1.0f;
 			try {
 				assertNotEquals(unexpected, actual);
 				expectAssertionFailedError();
@@ -361,8 +361,8 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void withEqualValuesWithMessage() {
-			float unexpected = 1.0f;
-			float actual = 1.0f;
+			var unexpected = 1.0f;
+			var actual = 1.0f;
 			try {
 				assertNotEquals(unexpected, actual, "custom message");
 				expectAssertionFailedError();
@@ -375,8 +375,8 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void withEqualValuesWithMessageSupplier() {
-			float unexpected = 1.0f;
-			float actual = 1.0f;
+			var unexpected = 1.0f;
+			var actual = 1.0f;
 			try {
 				assertNotEquals(unexpected, actual, () -> "custom message from supplier");
 				expectAssertionFailedError();
@@ -401,9 +401,9 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void withEqualValues() {
-			float unexpected = 1.0f;
-			float actual = 1.5f;
-			float delta = 0.5f;
+			var unexpected = 1.0f;
+			var actual = 1.5f;
+			var delta = 0.5f;
 			try {
 				assertNotEquals(unexpected, actual, delta);
 				expectAssertionFailedError();
@@ -415,9 +415,9 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void withEqualValuesWithMessage() {
-			float unexpected = 1.0f;
-			float actual = 1.5f;
-			float delta = 0.5f;
+			var unexpected = 1.0f;
+			var actual = 1.5f;
+			var delta = 0.5f;
 			try {
 				assertNotEquals(unexpected, actual, delta, "custom message");
 				expectAssertionFailedError();
@@ -430,9 +430,9 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void withEqualValuesWithMessageSupplier() {
-			float unexpected = 1.0f;
-			float actual = 1.5f;
-			float delta = 0.5f;
+			var unexpected = 1.0f;
+			var actual = 1.5f;
+			var delta = 0.5f;
 			try {
 				assertNotEquals(unexpected, actual, delta, () -> "custom message from supplier");
 				expectAssertionFailedError();
@@ -450,8 +450,8 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void assertNotEqualsDouble() {
-			double unexpected = 1.0d;
-			double actual = 2.0d;
+			var unexpected = 1.0d;
+			var actual = 2.0d;
 			assertNotEquals(unexpected, actual);
 			assertNotEquals(unexpected, actual, "message");
 			assertNotEquals(unexpected, actual, () -> "message");
@@ -470,8 +470,8 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void withEqualValues() {
-			double unexpected = 1.0d;
-			double actual = 1.0d;
+			var unexpected = 1.0d;
+			var actual = 1.0d;
 			try {
 				assertNotEquals(unexpected, actual);
 				expectAssertionFailedError();
@@ -483,8 +483,8 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void withEqualValuesWithMessage() {
-			double unexpected = 1.0d;
-			double actual = 1.0d;
+			var unexpected = 1.0d;
+			var actual = 1.0d;
 			try {
 				assertNotEquals(unexpected, actual, "custom message");
 				expectAssertionFailedError();
@@ -497,8 +497,8 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void withEqualValuesWithMessageSupplier() {
-			double unexpected = 1.0d;
-			double actual = 1.0d;
+			var unexpected = 1.0d;
+			var actual = 1.0d;
 			try {
 				assertNotEquals(unexpected, actual, () -> "custom message from supplier");
 				expectAssertionFailedError();
@@ -523,9 +523,9 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void withEqualValues() {
-			double unexpected = 1.0d;
-			double actual = 1.5d;
-			double delta = 0.5d;
+			var unexpected = 1.0d;
+			var actual = 1.5d;
+			var delta = 0.5d;
 			try {
 				assertNotEquals(unexpected, actual, delta);
 				expectAssertionFailedError();
@@ -537,9 +537,9 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void withEqualValuesWithMessage() {
-			double unexpected = 1.0d;
-			double actual = 1.5d;
-			double delta = 0.5d;
+			var unexpected = 1.0d;
+			var actual = 1.5d;
+			var delta = 0.5d;
 			try {
 				assertNotEquals(unexpected, actual, delta, "custom message");
 				expectAssertionFailedError();
@@ -552,9 +552,9 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void withEqualValuesWithMessageSupplier() {
-			double unexpected = 1.0d;
-			double actual = 1.5d;
-			double delta = 0.5d;
+			var unexpected = 1.0d;
+			var actual = 1.5d;
+			var delta = 0.5d;
 			try {
 				assertNotEquals(unexpected, actual, delta, () -> "custom message from supplier");
 				expectAssertionFailedError();
@@ -659,7 +659,7 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void integers() {
-			int primitive = 42;
+			var primitive = 42;
 			Integer wrapper = Integer.valueOf("99");
 
 			assertNotEquals(primitive, wrapper);
@@ -673,7 +673,7 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void longs() {
-			long primitive = 42L;
+			var primitive = 42L;
 			Long wrapper = Long.valueOf("99");
 
 			assertNotEquals(primitive, wrapper);
@@ -687,7 +687,7 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void floats() {
-			float primitive = 42.0f;
+			var primitive = 42.0f;
 			Float wrapper = Float.valueOf("99.0");
 
 			assertNotEquals(primitive, wrapper);
@@ -707,7 +707,7 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void doubles() {
-			double primitive = 42.0d;
+			var primitive = 42.0d;
 			Double wrapper = Double.valueOf("99.0");
 
 			assertNotEquals(primitive, wrapper);
@@ -727,7 +727,7 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void booleans() {
-			boolean primitive = true;
+			var primitive = true;
 			Boolean wrapper = Boolean.valueOf("false");
 
 			assertNotEquals(primitive, wrapper);
@@ -741,7 +741,7 @@ class AssertNotEqualsAssertionsTests {
 
 		@Test
 		void chars() {
-			char primitive = 'a';
+			var primitive = 'a';
 			Character wrapper = Character.valueOf('z');
 
 			assertNotEquals(primitive, wrapper);

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertSameAssertionsTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertSameAssertionsTests.java
@@ -86,7 +86,7 @@ class AssertSameAssertionsTests {
 	@Test
 	void assertSameWithEqualPrimitivesAutoboxedToDifferentWrappers() {
 		try {
-			int i = 999;
+			var i = 999;
 			assertSame(i, i);
 			expectAssertionFailedError();
 		}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertThrowsAssertionsTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertThrowsAssertionsTests.java
@@ -41,7 +41,7 @@ class AssertThrowsAssertionsTests {
 
 	@Test
 	void assertThrowsWithMethodReferenceForNonVoidReturnType() {
-		FutureTask<String> future = new FutureTask<>(() -> {
+		var future = new FutureTask<String>(() -> {
 			throw new RuntimeException("boom");
 		});
 		future.run();

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertThrowsExactlyAssertionsTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertThrowsExactlyAssertionsTests.java
@@ -81,7 +81,7 @@ class AssertThrowsExactlyAssertionsTests {
 
 	@Test
 	void assertThrowsWithMethodReferenceForNonVoidReturnType() {
-		FutureTask<String> future = new FutureTask<>(() -> {
+		var future = new FutureTask<String>(() -> {
 			throw new RuntimeException("boom");
 		});
 		future.run();

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertTimeoutAssertionsTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertTimeoutAssertionsTests.java
@@ -153,7 +153,7 @@ class AssertTimeoutAssertionsTests {
 	 * Take a nap for 100 milliseconds.
 	 */
 	private void nap() throws InterruptedException {
-		long start = System.nanoTime();
+		var start = System.nanoTime();
 		// workaround for imprecise clocks (yes, Windows, I'm talking about you)
 		do {
 			Thread.sleep(100);

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertTimeoutPreemptivelyAssertionsTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/AssertTimeoutPreemptivelyAssertionsTests.java
@@ -188,7 +188,7 @@ class AssertTimeoutPreemptivelyAssertionsTests {
 
 	@Test
 	void assertTimeoutPreemptivelyUsesThreadsWithSpecificNamePrefix() {
-		AtomicReference<String> threadName = new AtomicReference<>("");
+		var threadName = new AtomicReference<String>("");
 		assertTimeoutPreemptively(ofMillis(1000), () -> threadName.set(Thread.currentThread().getName()));
 		assertThat(threadName.get()) //
 				.withFailMessage("Thread name does not match the expected prefix") //

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/AssumptionsTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/AssumptionsTests.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.api.Assumptions.assumingThat;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
 import org.jspecify.annotations.Nullable;
@@ -163,7 +162,7 @@ class AssumptionsTests {
 
 	@Test
 	void assumingThatWithBooleanTrue() {
-		List<String> list = new ArrayList<>();
+		var list = new ArrayList<String>();
 		assumingThat(true, () -> list.add("test"));
 		assertEquals(1, list.size());
 		assertEquals("test", list.getFirst());
@@ -171,7 +170,7 @@ class AssumptionsTests {
 
 	@Test
 	void assumingThatWithBooleanSupplierTrue() {
-		List<String> list = new ArrayList<>();
+		var list = new ArrayList<String>();
 		assumingThat(() -> true, () -> list.add("test"));
 		assertEquals(1, list.size());
 		assertEquals("test", list.getFirst());
@@ -179,14 +178,14 @@ class AssumptionsTests {
 
 	@Test
 	void assumingThatWithBooleanFalse() {
-		List<String> list = new ArrayList<>();
+		var list = new ArrayList<String>();
 		assumingThat(false, () -> list.add("test"));
 		assertEquals(0, list.size());
 	}
 
 	@Test
 	void assumingThatWithBooleanSupplierFalse() {
-		List<String> list = new ArrayList<>();
+		var list = new ArrayList<String>();
 		assumingThat(() -> false, () -> list.add("test"));
 		assertEquals(0, list.size());
 	}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/api/FailAssertionsTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/api/FailAssertionsTests.java
@@ -142,7 +142,7 @@ class FailAssertionsTests {
 	@Test
 	void failUsableAsAnExpression() {
 		// @formatter:off
-		long count = Stream.empty()
+		var count = Stream.empty()
 				.peek(element -> fail("peek should never be called"))
 				.filter(element -> fail("filter should never be called", new Throwable("cause")))
 				.map(element -> Assertions.<Throwable> fail(new Throwable("map should never be called")))

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/ReportingTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/ReportingTests.java
@@ -119,7 +119,7 @@ class ReportingTests extends AbstractJupiterTestEngineTests {
 		void invalidReportData(TestReporter reporter) {
 
 			// Maps
-			Map<String, String> map = new HashMap<>();
+			var map = new HashMap<String, String>();
 
 			map.put("key", null);
 			assertPreconditionViolationFor(() -> reporter.publishEntry(map));

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/TestClassInheritanceTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/TestClassInheritanceTests.java
@@ -116,21 +116,21 @@ class TestClassInheritanceTests extends AbstractJupiterTestEngineTests {
 		// @formatter:on
 
 		// @formatter:off
-		assertEquals(asList(
-			"beforeAll1",
+		assertEquals(callSequence, asList(
+				"beforeAll1",
 				"beforeAll2",
-					"beforeAll3",
-						"beforeEach1",
-							"beforeEach2",
-								"beforeEach3",
-									"test3",
-								"afterEach3",
-							"afterEach2",
-						"afterEach1",
-					"afterAll3",
+				"beforeAll3",
+				"beforeEach1",
+				"beforeEach2",
+				"beforeEach3",
+				"test3",
+				"afterEach3",
+				"afterEach2",
+				"afterEach1",
+				"afterAll3",
 				"afterAll2",
-			"afterAll1"
-		), callSequence, "wrong call sequence");
+				"afterAll1"
+		), "wrong call sequence");
 		// @formatter:on
 	}
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/TestInstanceLifecycleConfigurationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/TestInstanceLifecycleConfigurationTests.java
@@ -138,7 +138,7 @@ class TestInstanceLifecycleConfigurationTests extends AbstractJupiterTestEngineT
 		executionResults.testEvents().assertStatistics(//
 			stats -> stats.started(numTests).finished(numTests));
 
-		assertEquals(Arrays.asList(methods), methodsInvoked);
+		assertEquals(methodsInvoked, Arrays.asList(methods));
 	}
 
 	// -------------------------------------------------------------------------

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/TestInstanceLifecycleKotlinTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/TestInstanceLifecycleKotlinTests.java
@@ -14,7 +14,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.platform.commons.util.CollectionUtils.getOnlyElement;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -57,7 +56,7 @@ class TestInstanceLifecycleKotlinTests extends AbstractJupiterTestEngineTests {
 		EngineExecutionResults executionResults = executeTestsForClass(testClass);
 
 		assertThat(executionResults.testEvents().finished().count()).isEqualTo(2);
-		List<Object> instances = new ArrayList<>(InstancePerMethodKotlinTestCase.TEST_INSTANCES.keySet());
+		var instances = new ArrayList<Object>(InstancePerMethodKotlinTestCase.TEST_INSTANCES.keySet());
 		assertThat(instances) //
 				.hasSize(3) //
 				.extracting(o -> (Object) o.getClass()) //

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/TestInstanceLifecycleTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/TestInstanceLifecycleTests.java
@@ -101,11 +101,11 @@ class TestInstanceLifecycleTests extends AbstractJupiterTestEngineTests {
 	@Test
 	void instancePerMethod() {
 		Class<?> testClass = InstancePerMethodTestCase.class;
-		int containers = 3;
-		int tests = 3;
+		var containers = 3;
+		var tests = 3;
 		Map.Entry<Class<?>, Integer>[] instances = instanceCounts(entry(InstancePerMethodTestCase.class, 3));
-		int allMethods = 1;
-		int eachMethods = 3;
+		var allMethods = 1;
+		var eachMethods = 3;
 
 		performAssertions(testClass, containers, tests, instances, allMethods, eachMethods);
 
@@ -185,10 +185,10 @@ class TestInstanceLifecycleTests extends AbstractJupiterTestEngineTests {
 
 	@SuppressWarnings("NullAway")
 	private void instancePerClass(Class<?> testClass, Map.Entry<Class<?>, Integer>[] instances) {
-		int containers = 3;
-		int tests = 3;
-		int allMethods = 2;
-		int eachMethods = 3;
+		var containers = 3;
+		var tests = 3;
+		var allMethods = 2;
+		var eachMethods = 3;
 
 		performAssertions(testClass, containers, tests, instances, allMethods, eachMethods);
 
@@ -256,11 +256,11 @@ class TestInstanceLifecycleTests extends AbstractJupiterTestEngineTests {
 	void instancePerMethodWithNestedTestClass() {
 		Class<?> testClass = InstancePerMethodOuterTestCase.class;
 		Class<?> nestedTestClass = InstancePerMethodOuterTestCase.NestedInstancePerMethodTestCase.class;
-		int containers = 4;
-		int tests = 4;
+		var containers = 4;
+		var tests = 4;
 		Map.Entry<Class<?>, Integer>[] instances = instanceCounts(entry(testClass, 4), entry(nestedTestClass, 3));
-		int allMethods = 1;
-		int eachMethods = 3;
+		var allMethods = 1;
+		var eachMethods = 3;
 
 		performAssertions(testClass, containers, tests, instances, allMethods, eachMethods);
 
@@ -379,11 +379,11 @@ class TestInstanceLifecycleTests extends AbstractJupiterTestEngineTests {
 	void instancePerClassWithNestedTestClass() {
 		Class<?> testClass = InstancePerClassOuterTestCase.class;
 		Class<?> nestedTestClass = InstancePerClassOuterTestCase.NestedInstancePerClassTestCase.class;
-		int containers = 4;
-		int tests = 4;
+		var containers = 4;
+		var tests = 4;
 		Map.Entry<Class<?>, Integer>[] instances = instanceCounts(entry(testClass, 1), entry(nestedTestClass, 1));
-		int allMethods = 2;
-		int eachMethods = 3;
+		var allMethods = 2;
+		var eachMethods = 3;
 
 		performAssertions(testClass, containers, tests, instances, allMethods, eachMethods);
 
@@ -500,11 +500,11 @@ class TestInstanceLifecycleTests extends AbstractJupiterTestEngineTests {
 	void instancePerMethodOnOuterTestClassWithInstancePerClassOnNestedTestClass() {
 		Class<?> testClass = MixedLifecyclesOuterTestCase.class;
 		Class<?> nestedTestClass = MixedLifecyclesOuterTestCase.NestedInstancePerClassTestCase.class;
-		int containers = 4;
-		int tests = 4;
+		var containers = 4;
+		var tests = 4;
 		Map.Entry<Class<?>, Integer>[] instances = instanceCounts(entry(testClass, 2), entry(nestedTestClass, 1));
-		int allMethods = 1;
-		int eachMethods = 7;
+		var allMethods = 1;
+		var eachMethods = 7;
 
 		performAssertions(testClass, containers, tests, instances, allMethods, eachMethods);
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/config/DefaultJupiterConfigurationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/config/DefaultJupiterConfigurationTests.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.mock;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -154,7 +153,7 @@ class DefaultJupiterConfigurationTests {
 
 	@Test
 	void doesNotReportAnyIssuesIfConfigurationParametersAreEmpty() {
-		List<DiscoveryIssue> issues = new ArrayList<>();
+		var issues = new ArrayList<DiscoveryIssue>();
 
 		new DefaultJupiterConfiguration(configurationParameters(Map.of()), dummyOutputDirectoryCreator(),
 			DiscoveryIssueReporter.collecting(issues)).getDefaultTestInstanceLifecycle();
@@ -168,7 +167,7 @@ class DefaultJupiterConfigurationTests {
 			ParallelExecutorServiceType executorServiceType) {
 		var parameters = Map.of(JupiterConfiguration.PARALLEL_EXECUTION_ENABLED_PROPERTY_NAME, true, //
 			JupiterConfiguration.PARALLEL_CONFIG_EXECUTOR_SERVICE_PROPERTY_NAME, executorServiceType);
-		List<DiscoveryIssue> issues = new ArrayList<>();
+		var issues = new ArrayList<DiscoveryIssue>();
 
 		new DefaultJupiterConfiguration(ConfigurationParametersFactoryForTests.create(parameters),
 			dummyOutputDirectoryCreator(), DiscoveryIssueReporter.collecting(issues)).getDefaultTestInstanceLifecycle();
@@ -179,7 +178,7 @@ class DefaultJupiterConfigurationTests {
 	@Test
 	void asksUsersToTryWorkerThreadPoolHierarchicalExecutorServiceIfParallelExecutionIsEnabled() {
 		var parameters = Map.of(JupiterConfiguration.PARALLEL_EXECUTION_ENABLED_PROPERTY_NAME, true);
-		List<DiscoveryIssue> issues = new ArrayList<>();
+		var issues = new ArrayList<DiscoveryIssue>();
 
 		new DefaultJupiterConfiguration(configurationParameters(parameters), dummyOutputDirectoryCreator(),
 			DiscoveryIssueReporter.collecting(issues)).getDefaultTestInstanceLifecycle();

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/config/InstantiatingConfigurationParameterConverterTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/config/InstantiatingConfigurationParameterConverterTests.java
@@ -41,7 +41,7 @@ class InstantiatingConfigurationParameterConverterTests {
 		ConfigurationParameters configurationParameters = mock();
 		when(configurationParameters.get(KEY)).thenReturn(Optional.of(CustomDisplayNameGenerator.class.getName()));
 
-		InstantiatingConfigurationParameterConverter<DisplayNameGenerator> converter = new InstantiatingConfigurationParameterConverter<>(
+		var converter = new InstantiatingConfigurationParameterConverter<DisplayNameGenerator>(
 			DisplayNameGenerator.class, "display name generator");
 		DisplayNameGenerator displayNameGenerator = converter.get(configurationParameters, KEY).orElseThrow();
 
@@ -57,7 +57,7 @@ class InstantiatingConfigurationParameterConverterTests {
 		ConfigurationParameters configurationParameters = mock();
 		when(configurationParameters.get(KEY)).thenReturn(Optional.empty());
 
-		InstantiatingConfigurationParameterConverter<DisplayNameGenerator> converter = new InstantiatingConfigurationParameterConverter<>(
+		var converter = new InstantiatingConfigurationParameterConverter<DisplayNameGenerator>(
 			DisplayNameGenerator.class, "display name generator");
 		Optional<DisplayNameGenerator> displayNameGenerator = converter.get(configurationParameters, KEY);
 
@@ -69,7 +69,7 @@ class InstantiatingConfigurationParameterConverterTests {
 		ConfigurationParameters configurationParameters = mock();
 		when(configurationParameters.get(KEY)).thenReturn(Optional.of(""));
 
-		InstantiatingConfigurationParameterConverter<DisplayNameGenerator> converter = new InstantiatingConfigurationParameterConverter<>(
+		var converter = new InstantiatingConfigurationParameterConverter<DisplayNameGenerator>(
 			DisplayNameGenerator.class, "display name generator");
 		Optional<DisplayNameGenerator> displayNameGenerator = converter.get(configurationParameters, KEY);
 
@@ -82,7 +82,7 @@ class InstantiatingConfigurationParameterConverterTests {
 		String classNameWithSpaces = " " + CustomDisplayNameGenerator.class.getName() + "  ";
 		when(configurationParameters.get(KEY)).thenReturn(Optional.of(classNameWithSpaces));
 
-		InstantiatingConfigurationParameterConverter<DisplayNameGenerator> converter = new InstantiatingConfigurationParameterConverter<>(
+		var converter = new InstantiatingConfigurationParameterConverter<DisplayNameGenerator>(
 			DisplayNameGenerator.class, "display name generator");
 		DisplayNameGenerator displayNameGenerator = converter.get(configurationParameters, KEY).orElseThrow();
 
@@ -98,7 +98,7 @@ class InstantiatingConfigurationParameterConverterTests {
 		ConfigurationParameters configurationParameters = mock();
 		when(configurationParameters.get(KEY)).thenReturn(Optional.of("random-string"));
 
-		InstantiatingConfigurationParameterConverter<DisplayNameGenerator> converter = new InstantiatingConfigurationParameterConverter<>(
+		var converter = new InstantiatingConfigurationParameterConverter<DisplayNameGenerator>(
 			DisplayNameGenerator.class, "display name generator");
 		Optional<DisplayNameGenerator> displayNameGenerator = converter.get(configurationParameters, KEY);
 
@@ -114,7 +114,7 @@ class InstantiatingConfigurationParameterConverterTests {
 		ConfigurationParameters configurationParameters = mock();
 		when(configurationParameters.get(KEY)).thenReturn(Optional.of(Object.class.getName()));
 
-		InstantiatingConfigurationParameterConverter<DisplayNameGenerator> converter = new InstantiatingConfigurationParameterConverter<>(
+		var converter = new InstantiatingConfigurationParameterConverter<DisplayNameGenerator>(
 			DisplayNameGenerator.class, "display name generator");
 		Optional<DisplayNameGenerator> displayNameGenerator = converter.get(configurationParameters, KEY);
 
@@ -131,7 +131,7 @@ class InstantiatingConfigurationParameterConverterTests {
 		when(configurationParameters.get(KEY)).thenReturn(
 			Optional.of(CustomDisplayNameGenerator.class.getSimpleName()));
 
-		InstantiatingConfigurationParameterConverter<DisplayNameGenerator> converter = new InstantiatingConfigurationParameterConverter<>(
+		var converter = new InstantiatingConfigurationParameterConverter<DisplayNameGenerator>(
 			DisplayNameGenerator.class, "display name generator");
 		Optional<DisplayNameGenerator> displayNameGenerator = converter.get(configurationParameters, KEY);
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/execution/injection/sample/LongParameterResolver.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/execution/injection/sample/LongParameterResolver.java
@@ -41,8 +41,8 @@ public class LongParameterResolver implements ParameterResolver {
 
 		// Type variables in parameterized class
 		for (TypeVariable<?> typeVariable : parameterContext.getDeclaringExecutable().getDeclaringClass().getTypeParameters()) {
-			boolean namesMatch = typeInMethod.getTypeName().equals(typeVariable.getName());
-			boolean typesAreCompatible = typeVariable.getBounds().length == 1 && //
+			var namesMatch = typeInMethod.getTypeName().equals(typeVariable.getName());
+			var typesAreCompatible = typeVariable.getBounds().length == 1 && //
 					typeVariable.getBounds()[0] instanceof Class<?> clazz && //
 					clazz.isAssignableFrom(Long.class);
 

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/execution/injection/sample/MapOfStringsParameterResolver.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/execution/injection/sample/MapOfStringsParameterResolver.java
@@ -12,7 +12,6 @@ package org.junit.jupiter.engine.execution.injection.sample;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.Map;
 import java.util.TreeMap;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -41,7 +40,7 @@ public class MapOfStringsParameterResolver implements ParameterResolver {
 
 	@Override
 	public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
-		Map<String, String> map = new TreeMap<>();
+		var map = new TreeMap<String, String>();
 		map.put("key", "value");
 		return map;
 	}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/BeforeAndAfterAllTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/BeforeAndAfterAllTests.java
@@ -182,7 +182,7 @@ class BeforeAndAfterAllTests extends AbstractJupiterTestEngineTests {
 		executeTestsForClass(testClass).testEvents()//
 				.assertStatistics(stats -> stats.started(testsStarted).succeeded(testsSuccessful));
 
-		assertEquals(asList(expectedCalls), callSequence, () -> "wrong call sequence for " + testClass.getName());
+		assertEquals(callSequence, asList(expectedCalls), () -> "wrong call sequence for " + testClass.getName());
 	}
 
 	// -------------------------------------------------------------------------

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/BeforeAndAfterEachTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/BeforeAndAfterEachTests.java
@@ -64,31 +64,31 @@ class BeforeAndAfterEachTests extends AbstractJupiterTestEngineTests {
 		assertEquals(0, testEvents.failed().count(), "# tests failed");
 
 		// @formatter:off
-		assertEquals(asList(
+		assertEquals(callSequence, asList(
 
-			// OuterTestCase
-			"fooBeforeEachCallback",
-			"barBeforeEachCallback",
+				// OuterTestCase
+				"fooBeforeEachCallback",
+				"barBeforeEachCallback",
 				"beforeEachMethod",
-					"testOuter",
+				"testOuter",
 				"afterEachMethod",
-			"barAfterEachCallback",
-			"fooAfterEachCallback",
+				"barAfterEachCallback",
+				"fooAfterEachCallback",
 
-			// InnerTestCase
-			"fooBeforeEachCallback",
-			"barBeforeEachCallback",
-			"fizzBeforeEachCallback",
+				// InnerTestCase
+				"fooBeforeEachCallback",
+				"barBeforeEachCallback",
+				"fizzBeforeEachCallback",
 				"beforeEachMethod",
-					"beforeEachInnerMethod",
-						"testInner",
-					"afterEachInnerMethod",
+				"beforeEachInnerMethod",
+				"testInner",
+				"afterEachInnerMethod",
 				"afterEachMethod",
-			"fizzAfterEachCallback",
-			"barAfterEachCallback",
-			"fooAfterEachCallback"
+				"fizzAfterEachCallback",
+				"barAfterEachCallback",
+				"fooAfterEachCallback"
 
-			), callSequence, "wrong call sequence");
+		), "wrong call sequence");
 		// @formatter:on
 	}
 
@@ -103,13 +103,13 @@ class BeforeAndAfterEachTests extends AbstractJupiterTestEngineTests {
 		assertEquals(0, testEvents.failed().count(), "# tests failed");
 
 		// @formatter:off
-		assertEquals(asList(
-			"fooBeforeEachCallback",
-			"barBeforeEachCallback",
+		assertEquals(callSequence, asList(
+				"fooBeforeEachCallback",
+				"barBeforeEachCallback",
 				"testChild",
-			"barAfterEachCallback",
-			"fooAfterEachCallback"
-		), callSequence, "wrong call sequence");
+				"barAfterEachCallback",
+				"fooAfterEachCallback"
+		), "wrong call sequence");
 		// @formatter:on
 	}
 
@@ -124,23 +124,23 @@ class BeforeAndAfterEachTests extends AbstractJupiterTestEngineTests {
 		assertEquals(0, testEvents.failed().count(), "# tests failed");
 
 		// @formatter:off
-		assertEquals(asList(
+		assertEquals(callSequence, asList(
 
-			// Test Interface
-			"fooBeforeEachCallback",
-			"barBeforeEachCallback",
+				// Test Interface
+				"fooBeforeEachCallback",
+				"barBeforeEachCallback",
 				"defaultTestMethod",
-			"barAfterEachCallback",
-			"fooAfterEachCallback",
+				"barAfterEachCallback",
+				"fooAfterEachCallback",
 
-			// Test Class
-			"fooBeforeEachCallback",
-			"barBeforeEachCallback",
+				// Test Class
+				"fooBeforeEachCallback",
+				"barBeforeEachCallback",
 				"localTestMethod",
-			"barAfterEachCallback",
-			"fooAfterEachCallback"
+				"barAfterEachCallback",
+				"fooAfterEachCallback"
 
-		), callSequence, "wrong call sequence");
+		), "wrong call sequence");
 		// @formatter:on
 	}
 
@@ -155,16 +155,16 @@ class BeforeAndAfterEachTests extends AbstractJupiterTestEngineTests {
 		assertEquals(1, testEvents.failed().count(), "# tests failed");
 
 		// @formatter:off
-		assertEquals(asList(
-			"fooBeforeEachCallback",
-			"exceptionThrowingBeforeEachCallback", // throws an exception.
-			// barBeforeEachCallback should not get invoked.
+		assertEquals(callSequence, asList(
+				"fooBeforeEachCallback",
+				"exceptionThrowingBeforeEachCallback", // throws an exception.
+				// barBeforeEachCallback should not get invoked.
 				// beforeEachMethod should not get invoked.
-					// test should not get invoked.
+				// test should not get invoked.
 				// afterEachMethod should not get invoked.
-			"barAfterEachCallback",
-			"fooAfterEachCallback"
-		), callSequence, "wrong call sequence");
+				"barAfterEachCallback",
+				"fooAfterEachCallback"
+		), "wrong call sequence");
 		// @formatter:on
 
 		assertThat(actualExceptionInAfterEachCallback).containsInstanceOf(EnigmaException.class);
@@ -181,16 +181,16 @@ class BeforeAndAfterEachTests extends AbstractJupiterTestEngineTests {
 		assertEquals(1, testEvents.failed().count(), "# tests failed");
 
 		// @formatter:off
-		assertEquals(asList(
-			"fooBeforeEachCallback",
-			"barBeforeEachCallback",
+		assertEquals(callSequence, asList(
+				"fooBeforeEachCallback",
+				"barBeforeEachCallback",
 				"beforeEachMethod",
-					"test",
+				"test",
 				"afterEachMethod",
-			"barAfterEachCallback",
-			"exceptionThrowingAfterEachCallback", // throws an exception.
-			"fooAfterEachCallback"
-		), callSequence, "wrong call sequence");
+				"barAfterEachCallback",
+				"exceptionThrowingAfterEachCallback", // throws an exception.
+				"fooAfterEachCallback"
+		), "wrong call sequence");
 		// @formatter:on
 
 		assertThat(actualExceptionInAfterEachCallback).containsInstanceOf(EnigmaException.class);
@@ -233,7 +233,7 @@ class BeforeAndAfterEachTests extends AbstractJupiterTestEngineTests {
 
 		List<String> expected = beforeEachMethodCallSequence.getFirst().equals("beforeEachMethod1") ? list1 : list2;
 
-		assertEquals(expected, callSequence, "wrong call sequence");
+		assertEquals(callSequence, expected, "wrong call sequence");
 
 		assertThat(actualExceptionInAfterEachCallback).containsInstanceOf(EnigmaException.class);
 	}
@@ -249,13 +249,13 @@ class BeforeAndAfterEachTests extends AbstractJupiterTestEngineTests {
 		assertEquals(1, testEvents.failed().count(), "# tests failed");
 
 		// @formatter:off
-		assertEquals(asList(
-			"fooBeforeEachCallback",
+		assertEquals(callSequence, asList(
+				"fooBeforeEachCallback",
 				"beforeEachMethod",
-					"test",
+				"test",
 				"afterEachMethod", // throws an exception.
-			"fooAfterEachCallback"
-		), callSequence, "wrong call sequence");
+				"fooAfterEachCallback"
+		), "wrong call sequence");
 		// @formatter:on
 
 		assertThat(actualExceptionInAfterEachCallback).containsInstanceOf(EnigmaException.class);
@@ -272,13 +272,13 @@ class BeforeAndAfterEachTests extends AbstractJupiterTestEngineTests {
 		assertEquals(1, testEvents.failed().count(), "# tests failed");
 
 		// @formatter:off
-		assertEquals(asList(
-			"fooBeforeEachCallback",
+		assertEquals(callSequence, asList(
+				"fooBeforeEachCallback",
 				"beforeEachMethod",
-					"test", // throws an exception.
+				"test", // throws an exception.
 				"afterEachMethod",
-			"fooAfterEachCallback"
-		), callSequence, "wrong call sequence");
+				"fooAfterEachCallback"
+		), "wrong call sequence");
 		// @formatter:on
 
 		assertThat(actualExceptionInAfterEachCallback).containsInstanceOf(EnigmaException.class);

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/BeforeAndAfterTestExecutionCallbackTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/BeforeAndAfterTestExecutionCallbackTests.java
@@ -65,31 +65,31 @@ class BeforeAndAfterTestExecutionCallbackTests extends AbstractJupiterTestEngine
 		assertEquals(0, executionResults.testEvents().failed().count(), "# tests failed");
 
 		// @formatter:off
-		assertEquals(asList(
+		assertEquals(callSequence, asList(
 
-			// OuterTestCase
-			"beforeEachMethodOuter",
+				// OuterTestCase
+				"beforeEachMethodOuter",
 				"fooBeforeTestExecutionCallback",
 				"barBeforeTestExecutionCallback",
-					"testOuter",
+				"testOuter",
 				"barAfterTestExecutionCallback",
 				"fooAfterTestExecutionCallback",
-			"afterEachMethodOuter",
+				"afterEachMethodOuter",
 
-			// InnerTestCase
-			"beforeEachMethodOuter",
+				// InnerTestCase
+				"beforeEachMethodOuter",
 				"beforeEachMethodInner",
-					"fooBeforeTestExecutionCallback",
-					"barBeforeTestExecutionCallback",
-						"fizzBeforeTestExecutionCallback",
-							"testInner",
-						"fizzAfterTestExecutionCallback",
-					"barAfterTestExecutionCallback",
-					"fooAfterTestExecutionCallback",
+				"fooBeforeTestExecutionCallback",
+				"barBeforeTestExecutionCallback",
+				"fizzBeforeTestExecutionCallback",
+				"testInner",
+				"fizzAfterTestExecutionCallback",
+				"barAfterTestExecutionCallback",
+				"fooAfterTestExecutionCallback",
 				"afterEachMethodInner",
-			"afterEachMethodOuter"
+				"afterEachMethodOuter"
 
-		), callSequence, "wrong call sequence");
+		), "wrong call sequence");
 		// @formatter:on
 	}
 
@@ -104,13 +104,13 @@ class BeforeAndAfterTestExecutionCallbackTests extends AbstractJupiterTestEngine
 		assertEquals(0, executionResults.testEvents().failed().count(), "# tests failed");
 
 		// @formatter:off
-		assertEquals(asList(
-			"fooBeforeTestExecutionCallback",
-			"barBeforeTestExecutionCallback",
+		assertEquals(callSequence, asList(
+				"fooBeforeTestExecutionCallback",
+				"barBeforeTestExecutionCallback",
 				"testChild",
-			"barAfterTestExecutionCallback",
-			"fooAfterTestExecutionCallback"
-		), callSequence, "wrong call sequence");
+				"barAfterTestExecutionCallback",
+				"fooAfterTestExecutionCallback"
+		), "wrong call sequence");
 		// @formatter:on
 	}
 
@@ -125,23 +125,23 @@ class BeforeAndAfterTestExecutionCallbackTests extends AbstractJupiterTestEngine
 		assertEquals(0, executionResults.testEvents().failed().count(), "# tests failed");
 
 		// @formatter:off
-		assertEquals(asList(
+		assertEquals(callSequence, asList(
 
-			// Test Interface
-			"fooBeforeTestExecutionCallback",
+				// Test Interface
+				"fooBeforeTestExecutionCallback",
 				"barBeforeTestExecutionCallback",
-					"defaultTestMethod",
+				"defaultTestMethod",
 				"barAfterTestExecutionCallback",
-			"fooAfterTestExecutionCallback",
+				"fooAfterTestExecutionCallback",
 
-			// Test Class
-			"fooBeforeTestExecutionCallback",
+				// Test Class
+				"fooBeforeTestExecutionCallback",
 				"barBeforeTestExecutionCallback",
-					"localTestMethod",
+				"localTestMethod",
 				"barAfterTestExecutionCallback",
-			"fooAfterTestExecutionCallback"
+				"fooAfterTestExecutionCallback"
 
-		), callSequence, "wrong call sequence");
+		), "wrong call sequence");
 		// @formatter:on
 	}
 
@@ -156,13 +156,13 @@ class BeforeAndAfterTestExecutionCallbackTests extends AbstractJupiterTestEngine
 		assertEquals(1, executionResults.testEvents().failed().count(), "# tests failed");
 
 		// @formatter:off
-		assertEquals(asList(
-			"beforeEachMethod", // throws an exception.
+		assertEquals(callSequence, asList(
+				"beforeEachMethod", // throws an exception.
 				// fooBeforeTestExecutionCallback should not get invoked.
-					// test should not get invoked.
+				// test should not get invoked.
 				// fooAfterTestExecutionCallback should not get invoked.
-			"afterEachMethod"
-		), callSequence, "wrong call sequence");
+				"afterEachMethod"
+		), "wrong call sequence");
 		// @formatter:on
 
 		assertNull(actualExceptionInAfterTestExecution,
@@ -181,16 +181,16 @@ class BeforeAndAfterTestExecutionCallbackTests extends AbstractJupiterTestEngine
 		assertEquals(1, executionResults.testEvents().failed().count(), "# tests failed");
 
 		// @formatter:off
-		assertEquals(asList(
-			"beforeEachMethod",
+		assertEquals(callSequence, asList(
+				"beforeEachMethod",
 				"fooBeforeTestExecutionCallback",
 				"exceptionThrowingBeforeTestExecutionCallback", // throws an exception.
 				// barBeforeTestExecutionCallback should not get invoked.
-					// test() should not get invoked.
+				// test() should not get invoked.
 				"barAfterTestExecutionCallback",
 				"fooAfterTestExecutionCallback",
-			"afterEachMethod"
-		), callSequence, "wrong call sequence");
+				"afterEachMethod"
+		), "wrong call sequence");
 		// @formatter:on
 
 		assertNotNull(actualExceptionInAfterTestExecution, "test exception");
@@ -210,16 +210,16 @@ class BeforeAndAfterTestExecutionCallbackTests extends AbstractJupiterTestEngine
 		assertEquals(1, executionResults.testEvents().failed().count(), "# tests failed");
 
 		// @formatter:off
-		assertEquals(asList(
-			"beforeEachMethod",
+		assertEquals(callSequence, asList(
+				"beforeEachMethod",
 				"fooBeforeTestExecutionCallback",
 				"barBeforeTestExecutionCallback",
-					"test",
+				"test",
 				"barAfterTestExecutionCallback",
 				"exceptionThrowingAfterTestExecutionCallback", // throws an exception.
 				"fooAfterTestExecutionCallback",
-			"afterEachMethod"
-		), callSequence, "wrong call sequence");
+				"afterEachMethod"
+		), "wrong call sequence");
 		// @formatter:on
 
 		assertNotNull(actualExceptionInAfterTestExecution, "test exception");
@@ -238,13 +238,13 @@ class BeforeAndAfterTestExecutionCallbackTests extends AbstractJupiterTestEngine
 		assertEquals(1, executionResults.testEvents().failed().count(), "# tests failed");
 
 		// @formatter:off
-		assertEquals(asList(
-			"beforeEachMethod",
+		assertEquals(callSequence, asList(
+				"beforeEachMethod",
 				"fooBeforeTestExecutionCallback",
-					"test", // throws an exception.
+				"test", // throws an exception.
 				"fooAfterTestExecutionCallback",
-			"afterEachMethod"
-		), callSequence, "wrong call sequence");
+				"afterEachMethod"
+		), "wrong call sequence");
 		// @formatter:on
 
 		assertNotNull(actualExceptionInAfterTestExecution, "test exception");

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/ExtensionRegistrationViaParametersAndFieldsTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/ExtensionRegistrationViaParametersAndFieldsTests.java
@@ -227,13 +227,13 @@ class ExtensionRegistrationViaParametersAndFieldsTests extends AbstractJupiterTe
 				.filter(message -> message.contains("local extension")) //
 				.map(message -> {
 					message = message.replaceAll(" from source .+", "");
-					int beginIndex = message.lastIndexOf('.') + 1;
+					var beginIndex = message.lastIndexOf('.') + 1;
 					if (message.contains("late-init")) {
 						return message.substring(beginIndex, message.indexOf("]"));
 					}
 					else {
-						int indexOfDollarSign = message.indexOf("$");
-						int indexOfAtSign = message.indexOf("@");
+						var indexOfDollarSign = message.indexOf("$");
+						var indexOfAtSign = message.indexOf("@");
 						int endIndex = (indexOfDollarSign > 1 ? indexOfDollarSign : indexOfAtSign);
 						return message.substring(beginIndex, endIndex);
 					}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/LifecycleMethodExecutionExceptionHandlerTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/LifecycleMethodExecutionExceptionHandlerTests.java
@@ -230,7 +230,7 @@ class LifecycleMethodExecutionExceptionHandlerTests extends AbstractJupiterTestE
 		throwExceptionAfterEach = false;
 		throwExceptionAfterAll = false;
 
-		boolean unrecoverableExceptionThrown = executeThrowingOutOfMemoryException();
+		var unrecoverableExceptionThrown = executeThrowingOutOfMemoryException();
 		assertTrue(unrecoverableExceptionThrown, "Unrecoverable Exception should be thrown");
 		assertEquals(1, UnrecoverableExceptionHandler.callCounter.beforeAllCalls,
 			"Exception should be handled in @BeforeAll");
@@ -245,7 +245,7 @@ class LifecycleMethodExecutionExceptionHandlerTests extends AbstractJupiterTestE
 		throwExceptionAfterEach = false;
 		throwExceptionAfterAll = false;
 
-		boolean unrecoverableExceptionThrown = executeThrowingOutOfMemoryException();
+		var unrecoverableExceptionThrown = executeThrowingOutOfMemoryException();
 		assertTrue(unrecoverableExceptionThrown, "Unrecoverable Exception should be thrown");
 		assertEquals(1, UnrecoverableExceptionHandler.callCounter.beforeEachCalls,
 			"Exception should be handled in @BeforeEach");
@@ -260,7 +260,7 @@ class LifecycleMethodExecutionExceptionHandlerTests extends AbstractJupiterTestE
 		throwExceptionAfterEach = true;
 		throwExceptionAfterAll = false;
 
-		boolean unrecoverableExceptionThrown = executeThrowingOutOfMemoryException();
+		var unrecoverableExceptionThrown = executeThrowingOutOfMemoryException();
 		assertTrue(unrecoverableExceptionThrown, "Unrecoverable Exception should be thrown");
 		assertEquals(1, UnrecoverableExceptionHandler.callCounter.afterEachCalls,
 			"Exception should be handled in @AfterEach");
@@ -275,7 +275,7 @@ class LifecycleMethodExecutionExceptionHandlerTests extends AbstractJupiterTestE
 		throwExceptionAfterEach = false;
 		throwExceptionAfterAll = true;
 
-		boolean unrecoverableExceptionThrown = executeThrowingOutOfMemoryException();
+		var unrecoverableExceptionThrown = executeThrowingOutOfMemoryException();
 		assertTrue(unrecoverableExceptionThrown, "Unrecoverable Exception should be thrown");
 		assertEquals(1, UnrecoverableExceptionHandler.callCounter.afterAllCalls,
 			"Exception should be handled in @AfterAll");

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/OrderedMethodTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/OrderedMethodTests.java
@@ -188,7 +188,7 @@ record OrderedMethodTests(ParallelExecutorServiceType executorServiceType) {
 			"Failed to convert configuration parameter \\[" + Pattern.quote(Random.RANDOM_SEED_PROPERTY_NAME)
 					+ "] with value \\[" + seed + "] to a long\\. Using default seed \\[\\d+] as fallback\\.");
 
-		Set<String> uniqueSequences = new HashSet<>();
+		var uniqueSequences = new HashSet<String>();
 
 		for (var i = 0; i < 10; i++) {
 			callSequence.clear();
@@ -212,7 +212,7 @@ record OrderedMethodTests(ParallelExecutorServiceType executorServiceType) {
 
 	@Test
 	void randomWithDifferentSeedConsecutively(@TrackLogRecords LogRecordListener listener) {
-		Set<String> uniqueSequences = new HashSet<>();
+		var uniqueSequences = new HashSet<String>();
 
 		for (var i = 0; i < 10; i++) {
 			var seed = String.valueOf(i);

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/RepeatedTestTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/RepeatedTestTests.java
@@ -384,7 +384,7 @@ class RepeatedTestTests extends AbstractJupiterTestEngineTests {
 
 		@RepeatedTest(value = 3, failureThreshold = 1)
 		void failureThreshold1() {
-			int count = counter.incrementAndGet();
+			var count = counter.incrementAndGet();
 			if (count > 1) {
 				fail("Boom!");
 			}
@@ -392,7 +392,7 @@ class RepeatedTestTests extends AbstractJupiterTestEngineTests {
 
 		@RepeatedTest(value = 4, failureThreshold = 2)
 		void failureThreshold2() {
-			int count = counter.incrementAndGet();
+			var count = counter.incrementAndGet();
 			if (count > 1) {
 				fail("Boom!");
 			}
@@ -400,7 +400,7 @@ class RepeatedTestTests extends AbstractJupiterTestEngineTests {
 
 		@RepeatedTest(value = 8, failureThreshold = 3)
 		void failureThreshold3() {
-			int count = counter.incrementAndGet();
+			var count = counter.incrementAndGet();
 			if ((count > 1) && (count % 2 == 0)) {
 				fail("Boom!");
 			}
@@ -408,7 +408,7 @@ class RepeatedTestTests extends AbstractJupiterTestEngineTests {
 
 		@RepeatedTest(value = 20, failureThreshold = 3)
 		void failureThresholdWithConcurrentExecution() {
-			int count = counter.incrementAndGet();
+			var count = counter.incrementAndGet();
 			if ((count > 1) && (count % 2 == 0)) {
 				fail("Boom!");
 			}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/SeparateThreadTimeoutInvocationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/SeparateThreadTimeoutInvocationTests.java
@@ -40,7 +40,7 @@ class SeparateThreadTimeoutInvocationTests {
 	@Test
 	@DisplayName("throws timeout exception when timeout duration is exceeded")
 	void throwsTimeoutException() {
-		AtomicReference<String> threadName = new AtomicReference<>();
+		var threadName = new AtomicReference<String>();
 		var invocation = aSeparateThreadInvocation(() -> {
 			threadName.set(Thread.currentThread().getName());
 			Thread.sleep(PREEMPTIVE_TIMEOUT_MILLIS * 2);

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TestInstancePostProcessorAndPreDestroyCallbackTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TestInstancePostProcessorAndPreDestroyCallbackTests.java
@@ -114,7 +114,7 @@ class TestInstancePostProcessorAndPreDestroyCallbackTests extends AbstractJupite
 		executeTestsForClass(testClass).testEvents()//
 				.assertStatistics(stats -> stats.started(1).succeeded(testsSuccessful));
 
-		assertEquals(asList(expectedCalls), callSequence, () -> "wrong call sequence for " + testClass.getName());
+		assertEquals(callSequence, asList(expectedCalls), () -> "wrong call sequence for " + testClass.getName());
 	}
 
 	// -------------------------------------------------------------------------

--- a/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TestWatcherTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/engine/extension/TestWatcherTests.java
@@ -117,7 +117,7 @@ class TestWatcherTests extends AbstractJupiterTestEngineTests {
 		assertCommonStatistics(executeTestsForClass(ExceptionThrowingTestWatcherTestCase.class));
 
 		// @formatter:off
-		long exceptionCount = logRecordListener.stream(MethodBasedTestDescriptor.class, Level.WARNING)
+		var exceptionCount = logRecordListener.stream(MethodBasedTestDescriptor.class, Level.WARNING)
 				.map(LogRecord::getThrown)
 				.filter(JUnitException.class::isInstance)
 				.map(throwable -> throwable.getStackTrace()[0].getMethodName())

--- a/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/rules/AbstractTestRuleAdapterTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/migrationsupport/rules/AbstractTestRuleAdapterTests.java
@@ -54,7 +54,7 @@ public class AbstractTestRuleAdapterTests {
 
 		JUnitException exception = assertThrows(JUnitException.class, adapter::before);
 
-		assertEquals(exception.getMessage(), "Failed to find method foo() in class org.junit.rules.ErrorCollector");
+		assertEquals("Failed to find method foo() in class org.junit.rules.ErrorCollector", exception.getMessage());
 	}
 
 	private static class TestableTestRuleAdapter extends AbstractTestRuleAdapter {

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedClassIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedClassIntegrationTests.java
@@ -286,7 +286,7 @@ public class ParameterizedClassIntegrationTests extends AbstractJupiterTestEngin
 		void annotationsAreInherited() {
 			var results = executeTestsForClass(ConcreteInheritanceTestCase.class);
 
-			int numArgumentSets = 13;
+			var numArgumentSets = 13;
 			var numContainers = numArgumentSets * 3; // once for outer invocation, once for nested class, once for inner invocation
 			var numTests = numArgumentSets * 2; // once for outer test, once for inner test
 			results.containerEvents() //

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/ParameterizedTestIntegrationTests.java
@@ -444,7 +444,7 @@ class ParameterizedTestIntegrationTests extends AbstractJupiterTestEngineTests {
 				.haveExactly(1,
 					event(test("test1"), displayName("[2] argument = bar"), finishedWithFailure(message("bar"))));
 
-		List<String> testMethods = new ArrayList<>(LifecycleTestCase.testMethods);
+		var testMethods = new ArrayList<String>(LifecycleTestCase.testMethods);
 
 		// @formatter:off
 		assertThat(LifecycleTestCase.lifecycleEvents).containsExactly(

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/aggregator/AggregatorIntegrationTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/aggregator/AggregatorIntegrationTests.java
@@ -279,7 +279,7 @@ public class AggregatorIntegrationTests {
 		@Override
 		protected Person aggregateArguments(ArgumentsAccessor accessor, Class<?> targetType,
 				AnnotatedElementContext context, int parameterIndex) {
-			int startIndex = context.findAnnotation(StartIndex.class).map(StartIndex::value).orElse(0);
+			var startIndex = context.findAnnotation(StartIndex.class).map(StartIndex::value).orElse(0);
 
 			// @formatter:off
 			return new Person(
@@ -297,7 +297,7 @@ public class AggregatorIntegrationTests {
 		@Override
 		public Address aggregateArguments(ArgumentsAccessor arguments, Class<?> targetType,
 				AnnotatedElementContext context, int parameterIndex) {
-			int startIndex = context.findAnnotation(StartIndex.class).map(StartIndex::value).orElse(0);
+			var startIndex = context.findAnnotation(StartIndex.class).map(StartIndex::value).orElse(0);
 
 			// @formatter:off
 			return new Address(

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/CsvArgumentsProviderTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/CsvArgumentsProviderTests.java
@@ -506,7 +506,7 @@ class CsvArgumentsProviderTests {
 		var arguments = provideArguments(csvSource);
 		return arguments.map(array -> {
 			String[] strings = new String[array.length];
-			for (int i = 0; i < array.length; i++) {
+			for (var i = 0; i < array.length; i++) {
 				if (array[i] instanceof ParameterNameAndArgument parameterNameAndArgument) {
 					strings[i] = parameterNameAndArgument.getName() + " = " + parameterNameAndArgument.getPayload();
 				}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/CsvFileArgumentsProviderTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/CsvFileArgumentsProviderTests.java
@@ -334,7 +334,7 @@ class CsvFileArgumentsProviderTests {
 
 		Stream<String[]> argumentsAsStrings = arguments.map(array -> {
 			String[] strings = new String[array.length];
-			for (int i = 0; i < array.length; i++) {
+			for (var i = 0; i < array.length; i++) {
 				if (array[i] instanceof ParameterNameAndArgument parameterNameAndArgument) {
 					strings[i] = parameterNameAndArgument.getName() + " = " + parameterNameAndArgument.getPayload();
 				}
@@ -477,7 +477,7 @@ class CsvFileArgumentsProviderTests {
 		try (var out = Files.newBufferedWriter(csvFile)) {
 			var chunks = 10;
 			var chunk = "a".repeat(8192);
-			for (long i = 0; i < chunks; i++) {
+			for (var i = 0L; i < chunks; i++) {
 				out.write(chunk);
 			}
 		}

--- a/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/FieldArgumentsProviderTests.java
+++ b/jupiter-tests/src/test/java/org/junit/jupiter/params/provider/FieldArgumentsProviderTests.java
@@ -340,7 +340,7 @@ class FieldArgumentsProviderTests {
 		void throwsExceptionWhenNonStaticExternalFieldIsReferencedWithLifecyclePerClassSemantics() {
 			var factoryClass = NonStaticTestCase.class.getName();
 			var field = factoryClass + "#nonStaticStringStreamSupplier";
-			boolean lifecyclePerClass = true;
+			var lifecyclePerClass = true;
 			assertPreconditionViolationFor(() -> provideArguments(TestCase.class, lifecyclePerClass, field).toArray())//
 					.withMessageContainingAll("Field '", "' must be static: local @FieldSource fields must be static ",
 						"unless the PER_CLASS @TestInstance lifecycle mode is used; ",

--- a/platform-tests/src/test/java/org/junit/platform/commons/support/ReflectionSupportTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/support/ReflectionSupportTests.java
@@ -98,8 +98,8 @@ class ReflectionSupportTests {
 
 	@TestFactory
 	List<DynamicTest> findAllClassesInClasspathRootDelegates() throws Throwable {
-		List<DynamicTest> tests = new ArrayList<>();
-		List<Path> paths = new ArrayList<>();
+		var tests = new ArrayList<DynamicTest>();
+		var paths = new ArrayList<Path>();
 		paths.add(Path.of(".").toRealPath());
 		paths.addAll(ReflectionUtils.getAllClasspathRootDirectories());
 		for (var path : paths) {
@@ -159,8 +159,8 @@ class ReflectionSupportTests {
 	@SuppressWarnings("removal")
 	@TestFactory
 	List<DynamicTest> findAllResourcesInClasspathRootDelegates() throws Throwable {
-		List<DynamicTest> tests = new ArrayList<>();
-		List<Path> paths = new ArrayList<>();
+		var tests = new ArrayList<DynamicTest>();
+		var paths = new ArrayList<Path>();
 		paths.add(Path.of(".").toRealPath());
 		paths.addAll(ReflectionUtils.getAllClasspathRootDirectories());
 		for (var path : paths) {
@@ -192,8 +192,8 @@ class ReflectionSupportTests {
 	@SuppressWarnings("removal")
 	@TestFactory
 	List<DynamicTest> streamAllResourcesInClasspathRootDelegates() throws Throwable {
-		List<DynamicTest> tests = new ArrayList<>();
-		List<Path> paths = new ArrayList<>();
+		var tests = new ArrayList<DynamicTest>();
+		var paths = new ArrayList<Path>();
 		paths.add(Path.of(".").toRealPath());
 		paths.addAll(ReflectionUtils.getAllClasspathRootDirectories());
 		for (var path : paths) {

--- a/platform-tests/src/test/java/org/junit/platform/commons/support/ResourceSupportTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/support/ResourceSupportTests.java
@@ -64,8 +64,8 @@ class ResourceSupportTests {
 	 */
 	@TestFactory
 	List<DynamicTest> findAllResourcesInClasspathRootDelegates() throws Throwable {
-		List<DynamicTest> tests = new ArrayList<>();
-		List<Path> paths = new ArrayList<>();
+		var tests = new ArrayList<DynamicTest>();
+		var paths = new ArrayList<Path>();
 		paths.add(Path.of(".").toRealPath());
 		paths.addAll(ReflectionUtils.getAllClasspathRootDirectories());
 		for (var path : paths) {
@@ -96,8 +96,8 @@ class ResourceSupportTests {
 	 */
 	@TestFactory
 	List<DynamicTest> streamAllResourcesInClasspathRootDelegates() throws Throwable {
-		List<DynamicTest> tests = new ArrayList<>();
-		List<Path> paths = new ArrayList<>();
+		var tests = new ArrayList<DynamicTest>();
+		var paths = new ArrayList<Path>();
 		paths.add(Path.of(".").toRealPath());
 		paths.addAll(ReflectionUtils.getAllClasspathRootDirectories());
 		for (var path : paths) {

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/DefaultClasspathScannerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/DefaultClasspathScannerTests.java
@@ -278,7 +278,7 @@ class DefaultClasspathScannerTests {
 
 	private static String jarFileAndEntry(URI uri) {
 		var uriString = uri.toString();
-		int lastJarUriSeparator = uriString.lastIndexOf("!/");
+		var lastJarUriSeparator = uriString.lastIndexOf("!/");
 		var jarUri = uriString.substring(0, lastJarUriSeparator);
 		var jarEntry = uriString.substring(lastJarUriSeparator + 1);
 		var fileName = jarUri.substring(jarUri.lastIndexOf("/") + 1);

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ReflectionUtilsTests.java
@@ -1945,7 +1945,7 @@ class ReflectionUtilsTests {
 		@SuppressWarnings("DataFlowIssue")
 		@Test
 		void readFieldValuesPreconditions() {
-			List<Field> fields = new ArrayList<>();
+			var fields = new ArrayList<Field>();
 			assertPreconditionViolationFor(() -> readFieldValues(null, new Object()));
 			assertPreconditionViolationFor(() -> readFieldValues(fields, null, null));
 			assertPreconditionViolationFor(() -> readFieldValues(fields, new Object(), null));

--- a/platform-tests/src/test/java/org/junit/platform/commons/util/ToStringBuilderTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/commons/util/ToStringBuilderTests.java
@@ -14,7 +14,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.platform.commons.test.PreconditionAssertions.assertPreconditionViolationFor;
 
 import java.util.LinkedHashMap;
-import java.util.Map;
 
 import org.jspecify.annotations.NullUnmarked;
 import org.junit.jupiter.api.Test;
@@ -129,10 +128,9 @@ class ToStringBuilderTests {
 	@SuppressWarnings("serial")
 	void withMapField() {
 		// @formatter:off
-		Map<String,Object> map = new LinkedHashMap<>() {{
-			put("foo", 42);
-			put("bar", "enigma");
-		}};
+		var map = new LinkedHashMap<String, Object>();
+		map.put("foo", 42);
+		map.put("bar", "enigma");
 		// @formatter:on
 		assertEquals("RoleModel [mystery map = {foo=42, bar=enigma}]",
 			new ToStringBuilder(new RoleModel()).append("mystery map", map).toString());

--- a/platform-tests/src/test/java/org/junit/platform/console/ConsoleDetailsTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/ConsoleDetailsTests.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Disabled;
@@ -76,8 +75,8 @@ class ConsoleDetailsTests {
 	private List<DynamicNode> scanContainerClassAndCreateDynamicTests(Class<?> containerClass) {
 		var containerName = containerClass.getSimpleName().replace("TestCase", "");
 		// String containerName = containerClass.getSimpleName();
-		List<DynamicNode> nodes = new ArrayList<>();
-		Map<Details, List<DynamicTest>> map = new EnumMap<>(Details.class);
+		var nodes = new ArrayList<DynamicNode>();
+		var map = new EnumMap<Details, List<DynamicTest>>(Details.class);
 		for (var method : findMethods(containerClass, m -> m.isAnnotationPresent(Test.class), TOP_DOWN)) {
 			var methodName = method.getName();
 			var types = method.getParameterTypes();
@@ -184,12 +183,12 @@ class ConsoleDetailsTests {
 
 		@Test
 		void reportMultiEntriesWithMultiMappings(TestReporter reporter) {
-			Map<String, String> values = new LinkedHashMap<>();
+			var values = new LinkedHashMap<String, String>();
 			values.put("user name", "dk38");
 			values.put("award year", "1974");
 			reporter.publishEntry(values);
 			reporter.publishEntry("single", "mapping");
-			Map<String, String> more = new LinkedHashMap<>();
+			var more = new LinkedHashMap<String, String>();
 			more.put("user name", "st77");
 			more.put("award year", "1977");
 			more.put("last seen", "2001");

--- a/platform-tests/src/test/java/org/junit/platform/console/ConsoleLauncherWrapper.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/ConsoleLauncherWrapper.java
@@ -53,7 +53,7 @@ class ConsoleLauncherWrapper {
 		var outText = out.toString();
 		var errText = err.toString();
 		if (expectedCode.isPresent()) {
-			int expectedValue = expectedCode.get();
+			var expectedValue = expectedCode.get();
 			assertEquals(expectedValue, code, "ConsoleLauncher execute code mismatch!");
 			if (expectedValue != 0 && expectedValue != 1) {
 				assertThat(errText).isNotBlank();

--- a/platform-tests/src/test/java/org/junit/platform/console/command/CustomContextClassLoaderExecutorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/command/CustomContextClassLoaderExecutorTests.java
@@ -33,7 +33,7 @@ class CustomContextClassLoaderExecutorTests {
 		var originalClassLoader = Thread.currentThread().getContextClassLoader();
 		var executor = new CustomContextClassLoaderExecutor(Optional.empty());
 
-		int result = executor.invoke(() -> {
+		var result = executor.invoke(() -> {
 			assertSame(originalClassLoader, Thread.currentThread().getContextClassLoader());
 			return 42;
 		});
@@ -48,7 +48,7 @@ class CustomContextClassLoaderExecutorTests {
 		ClassLoader customClassLoader = URLClassLoader.newInstance(new URL[0]);
 		var executor = new CustomContextClassLoaderExecutor(Optional.of(customClassLoader));
 
-		int result = executor.invoke(() -> {
+		var result = executor.invoke(() -> {
 			assertSame(customClassLoader, Thread.currentThread().getContextClassLoader());
 			return 23;
 		});
@@ -69,7 +69,7 @@ class CustomContextClassLoaderExecutorTests {
 		};
 		var executor = new CustomContextClassLoaderExecutor(Optional.of(localClassLoader));
 
-		int result = executor.invoke(() -> 4711);
+		var result = executor.invoke(() -> 4711);
 
 		assertEquals(4711, result);
 		assertTrue(closed.get());
@@ -88,7 +88,7 @@ class CustomContextClassLoaderExecutorTests {
 		var executor = new CustomContextClassLoaderExecutor(Optional.of(localClassLoader),
 			CustomClassLoaderCloseStrategy.KEEP_OPEN);
 
-		int result = executor.invoke(() -> 4711);
+		var result = executor.invoke(() -> 4711);
 
 		assertEquals(4711, result);
 		assertFalse(closed.get());

--- a/platform-tests/src/test/java/org/junit/platform/console/output/TreeNodeTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/console/output/TreeNodeTests.java
@@ -46,7 +46,7 @@ class TreeNodeTests {
 		var treeNode = new TreeNode("root");
 
 		runConcurrently(() -> {
-			for (long i = 0; i < ITEMS_PER_THREAD; i++) {
+			for (var i = 0L; i < ITEMS_PER_THREAD; i++) {
 				treeNode.addChild(new TreeNode(String.valueOf(i)));
 			}
 		});
@@ -59,7 +59,7 @@ class TreeNodeTests {
 		var treeNode = new TreeNode("root");
 
 		runConcurrently(() -> {
-			for (long i = 0; i < ITEMS_PER_THREAD; i++) {
+			for (var i = 0L; i < ITEMS_PER_THREAD; i++) {
 				treeNode.addReportEntry(ReportEntry.from("index", String.valueOf(i)));
 			}
 		});
@@ -73,7 +73,7 @@ class TreeNodeTests {
 			new ArrayBlockingQueue<>(NUM_THREADS));
 		try {
 			var barrier = new CyclicBarrier(NUM_THREADS);
-			for (long i = 0; i < NUM_THREADS; i++) {
+			for (var i = 0L; i < NUM_THREADS; i++) {
 				executor.submit(() -> {
 					await(barrier);
 					action.run();

--- a/platform-tests/src/test/java/org/junit/platform/engine/FilterCompositionTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/FilterCompositionTests.java
@@ -62,8 +62,8 @@ class FilterCompositionTests {
 
 	@Test
 	void aFilterComposedOfMultipleFiltersHasReadableDescription() {
-		Filter<Object> firstFilter = new FilterStub<>(o -> excluded("wrong"), () -> "1st");
-		Filter<Object> secondFilter = new FilterStub<>(o -> included("right"), () -> "2nd");
+		var firstFilter = new FilterStub<Object>(o -> excluded("wrong"), () -> "1st");
+		var secondFilter = new FilterStub<Object>(o -> included("right"), () -> "2nd");
 
 		var composed = Filter.composeFilters(firstFilter, secondFilter);
 

--- a/platform-tests/src/test/java/org/junit/platform/engine/TestTagTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/TestTagTests.java
@@ -80,7 +80,7 @@ class TestTagTests {
 		assertEquals(TestTag.create("fast"), TestTag.create("fast"));
 		assertEquals(TestTag.create("fast").hashCode(), TestTag.create("fast").hashCode());
 		assertNotEquals(null, TestTag.create("fast"));
-		assertNotEquals(TestTag.create("fast"), null);
+		assertNotEquals(null, TestTag.create("fast"));
 	}
 
 	@Test

--- a/platform-tests/src/test/java/org/junit/platform/engine/UniqueIdTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/UniqueIdTests.java
@@ -160,7 +160,7 @@ class UniqueIdTests {
 
 		@Test
 		void ensureDefaultUniqueIdFormatCanHandleAllCharacters() {
-			for (char c = 0; c < Character.MAX_VALUE; c++) {
+			for (var c = 0; c < Character.MAX_VALUE; c++) {
 				var value = "foo " + c + " bar";
 				var uniqueId = UniqueId.parse(UniqueId.root("type", value).toString());
 				var segment = uniqueId.getSegments().getFirst();

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptorTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/AbstractTestDescriptorTests.java
@@ -105,7 +105,7 @@ class AbstractTestDescriptorTests implements TestDescriptorOrderChildrenTests {
 
 	@Test
 	void visitAllNodes() {
-		List<TestDescriptor> visited = new ArrayList<>();
+		var visited = new ArrayList<TestDescriptor>();
 		engineDescriptor.accept(visited::add);
 
 		assertEquals(8, visited.size());
@@ -120,7 +120,7 @@ class AbstractTestDescriptorTests implements TestDescriptorOrderChildrenTests {
 		};
 		engineDescriptor.accept(visitor);
 
-		List<UniqueId> visited = new ArrayList<>();
+		var visited = new ArrayList<UniqueId>();
 		engineDescriptor.accept(descriptor -> visited.add(descriptor.getUniqueId()));
 
 		assertEquals(7, visited.size());
@@ -141,7 +141,7 @@ class AbstractTestDescriptorTests implements TestDescriptorOrderChildrenTests {
 
 		assertEquals(4, countVisited.get(), "Children of pruned element are not visited");
 
-		List<UniqueId> visited = new ArrayList<>();
+		var visited = new ArrayList<UniqueId>();
 		engineDescriptor.accept(descriptor -> visited.add(descriptor.getUniqueId()));
 
 		assertEquals(3, visited.size());

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/TestDescriptorOrderChildrenTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/descriptor/TestDescriptorOrderChildrenTests.java
@@ -47,7 +47,7 @@ public interface TestDescriptorOrderChildrenTests {
 			children.sort(comparing((TestDescriptor o) -> childrenInOriginalOrder.indexOf(o)).reversed());
 			return children;
 		});
-		List<TestDescriptor> children = new ArrayList<>(testDescriptor.getChildren());
+		var children = new ArrayList<TestDescriptor>(testDescriptor.getChildren());
 		assertThat(children).isEqualTo(childrenInOriginalOrder.reversed());
 	}
 
@@ -66,7 +66,7 @@ public interface TestDescriptorOrderChildrenTests {
 			children.sort(comparing(childrenInOriginalOrder::indexOf));
 			return children;
 		});
-		List<TestDescriptor> children = new ArrayList<>(testDescriptor.getChildren());
+		var children = new ArrayList<TestDescriptor>(testDescriptor.getChildren());
 		assertThat(children).isEqualTo(childrenInOriginalOrder);
 	}
 
@@ -125,7 +125,7 @@ public interface TestDescriptorOrderChildrenTests {
 	@Test
 	default void orderChildrenProvidedChildrenAreModifiable() {
 		var testDescriptor = createTestDescriptorWithChildren();
-		AtomicReference<List<TestDescriptor>> childrenRef = new AtomicReference<>();
+		var childrenRef = new AtomicReference<List<TestDescriptor>>();
 		testDescriptor.orderChildren(children -> {
 			childrenRef.set(children);
 			return children;

--- a/platform-tests/src/test/java/org/junit/platform/engine/support/store/NamespacedHierarchicalStoreTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/engine/support/store/NamespacedHierarchicalStoreTests.java
@@ -211,11 +211,11 @@ public class NamespacedHierarchicalStoreTests {
 		@Test
 		void getWithTypeSafetyAndPrimitiveValueType() {
 			String key = "enigma";
-			int value = 42;
+			var value = 42;
 			store.put(namespace, key, value);
 
 			// The fact that we can declare this as an int/Integer suffices for testing the required type.
-			int requiredInt = store.get(namespace, key, int.class);
+			var requiredInt = store.get(namespace, key, int.class);
 			Integer requiredInteger = store.get(namespace, key, Integer.class);
 			assertEquals(value, requiredInt);
 			assertEquals(value, requiredInteger.intValue());
@@ -292,10 +292,10 @@ public class NamespacedHierarchicalStoreTests {
 		@Test
 		void getOrComputeIfAbsentWithTypeSafetyAndPrimitiveValueType() {
 			String key = "enigma";
-			int value = 42;
+			var value = 42;
 
 			// The fact that we can declare this as an int/Integer suffices for testing the required type.
-			int computedInt = store.getOrComputeIfAbsent(namespace, key, k -> value, int.class);
+			var computedInt = store.getOrComputeIfAbsent(namespace, key, k -> value, int.class);
 			Integer computedInteger = store.getOrComputeIfAbsent(namespace, key, k -> value, Integer.class);
 			assertEquals(value, computedInt);
 			assertEquals(value, computedInteger.intValue());
@@ -304,10 +304,10 @@ public class NamespacedHierarchicalStoreTests {
 		@Test
 		void computeIfAbsentWithTypeSafetyAndPrimitiveValueType() {
 			String key = "enigma";
-			int value = 42;
+			var value = 42;
 
 			// The fact that we can declare this as an int/Integer suffices for testing the required type.
-			int computedInt = store.computeIfAbsent(namespace, key, k -> value, int.class);
+			var computedInt = store.computeIfAbsent(namespace, key, k -> value, int.class);
 			Integer computedInteger = store.computeIfAbsent(namespace, key, k -> value, Integer.class);
 			assertEquals(value, computedInt);
 			assertEquals(value, computedInteger.intValue());
@@ -361,11 +361,11 @@ public class NamespacedHierarchicalStoreTests {
 		@Test
 		void removeWithTypeSafetyAndPrimitiveValueType() {
 			String key = "enigma";
-			int value = 42;
+			var value = 42;
 			store.put(namespace, key, value);
 
 			// The fact that we can declare this as an int suffices for testing the required type.
-			int requiredInt = store.remove(namespace, key, int.class);
+			var requiredInt = store.remove(namespace, key, int.class);
 			assertEquals(value, requiredInt);
 
 			store.put(namespace, key, value);
@@ -388,7 +388,7 @@ public class NamespacedHierarchicalStoreTests {
 		@SuppressWarnings("deprecation")
 		@Test
 		void simulateRaceConditionInGetOrComputeIfAbsent() throws Exception {
-			int threads = 10;
+			var threads = 10;
 			AtomicInteger counter = new AtomicInteger();
 			List<Object> values;
 
@@ -404,7 +404,7 @@ public class NamespacedHierarchicalStoreTests {
 
 		@Test
 		void simulateRaceConditionInComputeIfAbsent() throws Exception {
-			int threads = 10;
+			var threads = 10;
 			AtomicInteger counter = new AtomicInteger();
 			List<Object> values;
 

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/DefaultLauncherTests.java
@@ -1046,13 +1046,13 @@ class DefaultLauncherTests {
 			UnaryOperator<LauncherExecutionRequestBuilder> executionConfigurer) {
 		var executionListener = mock(TestExecutionListener.class);
 
-		AtomicReference<Instant> startTime = new AtomicReference<>();
+		var startTime = new AtomicReference<Instant>();
 		doAnswer(invocation -> {
 			startTime.set(Instant.now());
 			return null;
 		}).when(executionListener).executionStarted(any());
 
-		AtomicReference<Instant> finishTime = new AtomicReference<>();
+		var finishTime = new AtomicReference<Instant>();
 		doAnswer(invocation -> {
 			finishTime.set(Instant.now());
 			return null;

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilderTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherDiscoveryRequestBuilderTests.java
@@ -295,7 +295,7 @@ class LauncherDiscoveryRequestBuilderTests {
 
 		@Test
 		void multipleConfigurationParametersAddedByMap_areStoredInDiscoveryRequest() {
-			Map<String, String> configurationParams = new HashMap<>();
+			var configurationParams = new HashMap<String, String>();
 			configurationParams.put("key1", "value1");
 			configurationParams.put("key2", "value2");
 

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherDiscoveryResultTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherDiscoveryResultTests.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.LinkedHashMap;
-import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.junit.platform.engine.EngineDiscoveryRequest;
@@ -41,14 +40,11 @@ class LauncherDiscoveryResultTests {
 		var engine4 = new DemoEngine("Engine 4");
 
 		@SuppressWarnings("serial")
-		Map<TestEngine, EngineResultInfo> engineResults = new LinkedHashMap<>() {
-			{
-				put(engine1, new DemoEngineResultInfo(true));
-				put(engine2, new DemoEngineResultInfo(false));
-				put(engine3, new DemoEngineResultInfo(false));
-				put(engine4, new DemoEngineResultInfo(true));
-			}
-		};
+		var engineResults = new LinkedHashMap<TestEngine, EngineResultInfo>();
+		engineResults.put(engine1, new DemoEngineResultInfo(true));
+		engineResults.put(engine2, new DemoEngineResultInfo(false));
+		engineResults.put(engine3, new DemoEngineResultInfo(false));
+		engineResults.put(engine4, new DemoEngineResultInfo(true));
 		assertThat(engineResults.keySet()).containsExactly(engine1, engine2, engine3, engine4);
 
 		LauncherDiscoveryResult discoveryResult = new LauncherDiscoveryResult(engineResults, mock(), mock());

--- a/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherFactoryTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/core/LauncherFactoryTests.java
@@ -319,7 +319,7 @@ class LauncherFactoryTests {
 					.addTestEngines(engine) //
 					.build();
 
-			AtomicReference<TestExecutionResult> result = new AtomicReference<>();
+			var result = new AtomicReference<TestExecutionResult>();
 			var listener = new TestExecutionListener() {
 				@Override
 				public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
@@ -354,7 +354,7 @@ class LauncherFactoryTests {
 
 		try (LauncherSession session = LauncherFactory.openSession(config)) {
 
-			AtomicReference<Throwable> errorRef = new AtomicReference<>();
+			var errorRef = new AtomicReference<Throwable>();
 			var listener = new TestExecutionListener() {
 				@Override
 				public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
@@ -382,7 +382,7 @@ class LauncherFactoryTests {
 
 		try (LauncherSession session = LauncherFactory.openSession(config)) {
 
-			AtomicReference<Throwable> errorRef = new AtomicReference<>();
+			var errorRef = new AtomicReference<Throwable>();
 			var listener = new TestExecutionListener() {
 				@Override
 				public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {

--- a/platform-tests/src/test/java/org/junit/platform/launcher/listeners/UniqueIdTrackingListenerIntegrationTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/launcher/listeners/UniqueIdTrackingListenerIntegrationTests.java
@@ -189,7 +189,7 @@ class UniqueIdTrackingListenerIntegrationTests {
 		var customDir = workingDir.resolve("build/UniqueIdTrackingListenerIntegrationTests");
 		var prefix = DEFAULT_OUTPUT_FILE_PREFIX;
 
-		Map<String, String> configurationParameters = new HashMap<>();
+		var configurationParameters = new HashMap<String, String>();
 		configurationParameters.put(LISTENER_ENABLED_PROPERTY_NAME, "true");
 		configurationParameters.put(OUTPUT_DIR_PROPERTY_NAME, customDir.toAbsolutePath().toString());
 
@@ -212,7 +212,7 @@ class UniqueIdTrackingListenerIntegrationTests {
 	}
 
 	private List<String> executeTests(Map<String, String> configurationParameters, List<ClassSelector> classSelectors) {
-		List<String> uniqueIds = new ArrayList<>();
+		var uniqueIds = new ArrayList<String>();
 		var listener = new TestExecutionListener() {
 
 			@Nullable

--- a/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/legacy/xml/LegacyXmlReportGeneratingListenerTests.java
@@ -37,7 +37,6 @@ import java.time.Year;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.Set;
 
 import org.joox.Match;
@@ -408,7 +407,7 @@ class LegacyXmlReportGeneratingListenerTests {
 		var testIdentifier = testPlan.getTestIdentifier(childUniqueId);
 		listener.executionStarted(testIdentifier);
 		listener.reportingEntryPublished(testIdentifier, ReportEntry.from("foo", "bar"));
-		Map<String, String> map = new LinkedHashMap<>();
+		var map = new LinkedHashMap<String, String>();
 		map.put("bar", "baz");
 		map.put("qux", "foo");
 		listener.reportingEntryPublished(testIdentifier, ReportEntry.from(map));

--- a/platform-tests/src/test/java/org/junit/platform/reporting/open/xml/OpenTestReportGeneratingListenerTests.java
+++ b/platform-tests/src/test/java/org/junit/platform/reporting/open/xml/OpenTestReportGeneratingListenerTests.java
@@ -284,7 +284,7 @@ public class OpenTestReportGeneratingListenerTests {
 		var builder = new StringBuilder();
 
 		try (var serverSocket = new ServerSocket(0, 50, InetAddress.getLoopbackAddress())) { // Use any available port
-			int port = serverSocket.getLocalPort();
+			var port = serverSocket.getLocalPort();
 
 			// Start a daemon thread to accept the connection and read the XML
 			Thread serverThread = new Thread(() -> {


### PR DESCRIPTION
### Add `UseVarForPrimitive`


related to:

- https://github.com/junit-team/junit-framework/pull/5231
- https://github.com/junit-team/junit-framework/issues/5002
- https://github.com/apache/kafka/pull/21165

Kindly asking if this is something to consider for junit?

Might want to apply var style like achieved in:

- https://github.com/junit-team/junit-framework/pull/5231 


Also wishing you a wonderful Christmas 🎄

@vlsi @marcphilipp @mpkorstanje

<!-- Please describe your changes here and list any open questions you might have. -->

---

I hereby agree to the terms of the [JUnit Contributor License Agreement](https://github.com/junit-team/junit-framework/blob/002a0052926ddee57cf90580fa49bc37e5a72427/CONTRIBUTING.md#junit-contributor-license-agreement).

---

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Method [preconditions](https://docs.junit.org/snapshot/api/org.junit.platform.commons/org/junit/platform/commons/util/Preconditions.html) are checked and documented in the method's Javadoc
- [ ] [Coding conventions](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#coding-conventions) (e.g. for logging) have been followed
- [ ] Change is covered by [automated tests](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#tests) including corner cases, errors, and exception handling
- [ ] Public API has [Javadoc](https://github.com/junit-team/junit-framework/blob/HEAD/CONTRIBUTING.md#javadoc) and [`@API` annotations](https://apiguardian-team.github.io/apiguardian/docs/current/api/org/apiguardian/api/API.html)
- [ ] Change is documented in the [User Guide](https://docs.junit.org/snapshot/user-guide/) and [Release Notes](https://docs.junit.org/snapshot/user-guide/#release-notes)
